### PR TITLE
Fix compilation error when common/exit test is executed after protocol/protocol

### DIFF
--- a/test/lib/pgBackRestTest/Common/JobTest.pm
+++ b/test/lib/pgBackRestTest/Common/JobTest.pm
@@ -249,6 +249,12 @@ sub run
                 {
                     executeTest("find $self->{strGCovPath} -mindepth 1 -print0 | xargs -0 rm -rf");
                 }
+                # If the $strShimSrcPath directory exists, it must be deleted so that its contents left over from previous tests do
+                # not affect the current one.
+                elsif ($self->{oStorageTest}->pathExists($strShimSrcPath))
+                {
+                    executeTest("rm -rf $strShimSrcPath");
+                }
 
                 # Write build.processing to track processing of this test
                 $self->{oStorageTest}->put($strBuildProcessingFile);


### PR DESCRIPTION
The file protocol/helper.c remains in the $strShimSrcPath directory after executing the "--module=protocol --test=protocol" test. When executing the "--module=common --test=exit" test, the $strShimSrcPath/protocol/helper.c file was compiled instead of $strRepoCopySrcPath/protocol/helper.c. This led to the error, so the $strShimSrcPath directory must be deleted before running a test.
