### PR TITLE
ADBM-1154: The storageReadRemote method should return actual read bytes

### DIFF
--- a/src/storage/remote/read.c
+++ b/src/storage/remote/read.c
@@ -144,6 +144,7 @@ storageReadRemote(THIS_VOID, Buffer *buffer, bool block)
                         protocolClientDataEndGet(this->client);
                     }
 
+                    result += this->remaining;
 #ifdef DEBUG
                     this->protocolReadBytes += this->remaining;
 #endif

--- a/src/storage/remote/read.c
+++ b/src/storage/remote/read.c
@@ -144,7 +144,6 @@ storageReadRemote(THIS_VOID, Buffer *buffer, bool block)
                         protocolClientDataEndGet(this->client);
                     }
 
-                    result += this->remaining;
 #ifdef DEBUG
                     this->protocolReadBytes += this->remaining;
 #endif
@@ -155,21 +154,16 @@ storageReadRemote(THIS_VOID, Buffer *buffer, bool block)
             // Read if not eof
             if (!this->eof)
             {
-                // If the buffer can contain all remaining bytes
-                if (bufRemains(buffer) >= this->remaining)
+                size_t remains = bufRemains(buffer);
+                if (this->remaining < remains)
+                    remains = this->remaining;
+                bufCatSub(buffer, this->block, bufUsed(this->block) - this->remaining, remains);
+                result += remains;
+                this->remaining -= remains;
+                if (this->remaining == 0)
                 {
-                    bufCatSub(buffer, this->block, bufUsed(this->block) - this->remaining, this->remaining);
-
-                    this->remaining = 0;
                     bufFree(this->block);
                     this->block = NULL;
-                }
-                // Else read what we can
-                else
-                {
-                    size_t remains = bufRemains(buffer);
-                    bufCatSub(buffer, this->block, bufUsed(this->block) - this->remaining, remains);
-                    this->remaining -= remains;
                 }
             }
         }

--- a/test/src/module/storage/remoteTest.c
+++ b/test/src/module/storage/remoteTest.c
@@ -276,7 +276,9 @@ testRun(void)
         Buffer *buffer = bufNew(bufSize(contentBuf));
         TEST_ASSIGN(fileReadRaw, storageNewReadP(storageRepo, STRDEF("test.txt")), "new file");
         TEST_RESULT_BOOL(ioReadOpen(storageReadIo(fileReadRaw)), true, "open read");
-        TEST_RESULT_UINT(storageReadRemote(fileReadRaw->driver, buffer, true), bufUsed(contentBuf), "read file and check returned size");
+        size_t size;
+        TEST_ASSIGN(size, storageReadRemote(fileReadRaw->driver, buffer, true), "read file and save returned size");
+        TEST_RESULT_UINT(size, bufUsed(buffer), "check returned size");
         TEST_RESULT_VOID(ioReadClose(storageReadIo(fileReadRaw)), "close");
         TEST_RESULT_BOOL(bufFull(buffer), true, "check if fill buffer");
 

--- a/test/src/module/storage/remoteTest.c
+++ b/test/src/module/storage/remoteTest.c
@@ -278,6 +278,7 @@ testRun(void)
         TEST_RESULT_BOOL(ioReadOpen(storageReadIo(fileReadRaw)), true, "open read");
         TEST_RESULT_UINT(storageReadRemote(fileReadRaw->driver, bufferOut, true), bufSize(contentBuf), "read file");
         TEST_RESULT_VOID(ioReadClose(storageReadIo(fileReadRaw)), "close");
+        TEST_RESULT_BOOL(bufFull(bufferOut), true, "get file");
 
         // -------------------------------------------------------------------------------------------------------------------------
         TEST_TITLE("read file without compression");

--- a/test/src/module/storage/remoteTest.c
+++ b/test/src/module/storage/remoteTest.c
@@ -272,11 +272,11 @@ testRun(void)
         // Disable protocol compression in the storage object
         ((StorageRemote *)storageDriver(storageRepo))->compressLevel = 0;
 
-        StorageRead *fileReadRaw = NULL;
         Buffer *buffer = bufNew(bufUsed(contentBuf));
+        size_t size;
+        StorageRead *fileReadRaw;
         TEST_ASSIGN(fileReadRaw, storageNewReadP(storageRepo, STRDEF("test.txt")), "new file");
         TEST_RESULT_BOOL(ioReadOpen(storageReadIo(fileReadRaw)), true, "open read");
-        size_t size;
         TEST_ASSIGN(size, storageReadRemote(fileReadRaw->driver, buffer, true), "read file and save returned size");
         TEST_RESULT_UINT(size, bufUsed(buffer), "check returned size");
         TEST_RESULT_UINT(size, bufUsed(contentBuf), "returned size should be the same as the file size");

--- a/test/src/module/storage/remoteTest.c
+++ b/test/src/module/storage/remoteTest.c
@@ -276,7 +276,7 @@ testRun(void)
         Buffer *buffer = bufNew(bufSize(contentBuf));
         TEST_ASSIGN(fileReadRaw, storageNewReadP(storageRepo, STRDEF("test.txt")), "new file");
         TEST_RESULT_BOOL(ioReadOpen(storageReadIo(fileReadRaw)), true, "open read");
-        TEST_RESULT_UINT(storageReadRemote(fileReadRaw->driver, buffer, true), bufSize(contentBuf), "read file and check returned size");
+        TEST_RESULT_UINT(storageReadRemote(fileReadRaw->driver, buffer, true), bufUsed(contentBuf), "read file and check returned size");
         TEST_RESULT_VOID(ioReadClose(storageReadIo(fileReadRaw)), "close");
         TEST_RESULT_BOOL(bufFull(buffer), true, "check if fill buffer");
 

--- a/test/src/module/storage/remoteTest.c
+++ b/test/src/module/storage/remoteTest.c
@@ -276,9 +276,9 @@ testRun(void)
         Buffer *buffer = bufNew(bufSize(contentBuf));
         TEST_ASSIGN(fileReadRaw, storageNewReadP(storageRepo, STRDEF("test.txt")), "new file");
         TEST_RESULT_BOOL(ioReadOpen(storageReadIo(fileReadRaw)), true, "open read");
-        TEST_RESULT_UINT(storageReadRemote(fileReadRaw->driver, buffer, true), bufSize(contentBuf), "read file");
+        TEST_RESULT_UINT(storageReadRemote(fileReadRaw->driver, buffer, true), bufSize(contentBuf), "read file and check returned size");
         TEST_RESULT_VOID(ioReadClose(storageReadIo(fileReadRaw)), "close");
-        TEST_RESULT_BOOL(bufFull(buffer), true, "check full");
+        TEST_RESULT_BOOL(bufFull(buffer), true, "check if fill buffer");
 
         // -------------------------------------------------------------------------------------------------------------------------
         TEST_TITLE("read file without compression");

--- a/test/src/module/storage/remoteTest.c
+++ b/test/src/module/storage/remoteTest.c
@@ -273,12 +273,12 @@ testRun(void)
         ((StorageRemote *)storageDriver(storageRepo))->compressLevel = 0;
 
         StorageRead *fileReadRaw = NULL;
-        Buffer *bufferOut = bufNew(bufSize(contentBuf));
+        Buffer *buffer = bufNew(bufSize(contentBuf));
         TEST_ASSIGN(fileReadRaw, storageNewReadP(storageRepo, STRDEF("test.txt")), "new file");
         TEST_RESULT_BOOL(ioReadOpen(storageReadIo(fileReadRaw)), true, "open read");
-        TEST_RESULT_UINT(storageReadRemote(fileReadRaw->driver, bufferOut, true), bufSize(contentBuf), "read file");
+        TEST_RESULT_UINT(storageReadRemote(fileReadRaw->driver, buffer, true), bufSize(contentBuf), "read file");
         TEST_RESULT_VOID(ioReadClose(storageReadIo(fileReadRaw)), "close");
-        TEST_RESULT_BOOL(bufFull(bufferOut), true, "get file");
+        TEST_RESULT_BOOL(bufFull(buffer), true, "check full");
 
         // -------------------------------------------------------------------------------------------------------------------------
         TEST_TITLE("read file without compression");
@@ -311,7 +311,7 @@ testRun(void)
 
         size_t bufferOld = ioBufferSize();
         ioBufferSizeSet(11);
-        Buffer *buffer = bufNew(11);
+        buffer = bufNew(11);
 
         TEST_ASSIGN(fileRead, storageNewReadP(storageRepo, STRDEF("test.txt"), .limit = VARUINT64(11)), "get file");
         TEST_RESULT_BOOL(ioReadOpen(storageReadIo(fileRead)), true, "open read");

--- a/test/src/module/storage/remoteTest.c
+++ b/test/src/module/storage/remoteTest.c
@@ -265,6 +265,22 @@ testRun(void)
             "raised from remote-0 shim protocol: " STORAGE_ERROR_READ_MISSING, TEST_PATH "/pg256/test.txt");
 
         // -------------------------------------------------------------------------------------------------------------------------
+        TEST_TITLE("raw read file without compression");
+
+        HRN_STORAGE_PUT(storageTest, TEST_PATH "/repo128/test.txt", contentBuf);
+
+        // Disable protocol compression in the storage object
+        ((StorageRemote *)storageDriver(storageRepo))->compressLevel = 0;
+
+        StorageRead *fileReadRaw = NULL;
+        Buffer *bufferOut = bufNew(ioBufferSize());
+        TEST_ASSIGN(fileReadRaw, storageNewReadP(storageRepo, STRDEF("test.txt")), "new file");
+        TEST_RESULT_BOOL(ioReadOpen(storageReadIo(fileReadRaw)), true, "open read");
+        TEST_RESULT_UINT(storageReadRemote(fileReadRaw->driver, bufferOut, true), 16384, "read file");
+        TEST_RESULT_VOID(ioReadClose(storageReadIo(fileReadRaw)), "close");
+        TEST_RESULT_UINT(((StorageReadRemote *)fileReadRaw->driver)->protocolReadBytes, bufUsed(bufferOut), "check read size");
+
+        // -------------------------------------------------------------------------------------------------------------------------
         TEST_TITLE("read file without compression");
 
         HRN_STORAGE_PUT(storageTest, TEST_PATH "/repo128/test.txt", contentBuf);

--- a/test/src/module/storage/remoteTest.c
+++ b/test/src/module/storage/remoteTest.c
@@ -273,14 +273,14 @@ testRun(void)
         ((StorageRemote *)storageDriver(storageRepo))->compressLevel = 0;
 
         StorageRead *fileReadRaw = NULL;
-        Buffer *buffer = bufNew(bufSize(contentBuf));
+        Buffer *buffer = bufNew(bufUsed(contentBuf));
         TEST_ASSIGN(fileReadRaw, storageNewReadP(storageRepo, STRDEF("test.txt")), "new file");
         TEST_RESULT_BOOL(ioReadOpen(storageReadIo(fileReadRaw)), true, "open read");
         size_t size;
         TEST_ASSIGN(size, storageReadRemote(fileReadRaw->driver, buffer, true), "read file and save returned size");
         TEST_RESULT_UINT(size, bufUsed(buffer), "check returned size");
+        TEST_RESULT_UINT(size, bufUsed(contentBuf), "returned size should be the same as the file size");
         TEST_RESULT_VOID(ioReadClose(storageReadIo(fileReadRaw)), "close");
-        TEST_RESULT_BOOL(bufFull(buffer), true, "check if fill buffer");
 
         // -------------------------------------------------------------------------------------------------------------------------
         TEST_TITLE("read file without compression");

--- a/test/src/module/storage/remoteTest.c
+++ b/test/src/module/storage/remoteTest.c
@@ -273,12 +273,11 @@ testRun(void)
         ((StorageRemote *)storageDriver(storageRepo))->compressLevel = 0;
 
         StorageRead *fileReadRaw = NULL;
-        Buffer *bufferOut = bufNew(ioBufferSize());
+        Buffer *bufferOut = bufNew(bufSize(contentBuf));
         TEST_ASSIGN(fileReadRaw, storageNewReadP(storageRepo, STRDEF("test.txt")), "new file");
         TEST_RESULT_BOOL(ioReadOpen(storageReadIo(fileReadRaw)), true, "open read");
-        TEST_RESULT_UINT(storageReadRemote(fileReadRaw->driver, bufferOut, true), 16384, "read file");
+        TEST_RESULT_UINT(storageReadRemote(fileReadRaw->driver, bufferOut, true), bufSize(contentBuf), "read file");
         TEST_RESULT_VOID(ioReadClose(storageReadIo(fileReadRaw)), "close");
-        TEST_RESULT_UINT(((StorageReadRemote *)fileReadRaw->driver)->protocolReadBytes, bufUsed(bufferOut), "check read size");
 
         // -------------------------------------------------------------------------------------------------------------------------
         TEST_TITLE("read file without compression");


### PR DESCRIPTION
The storageReadRemote method should return actual read bytes

All interface read methods should return actual read bytes.
This patch refactors storageReadRemote method to simplify it,
to eliminate duplicate code and to return actual read bytes.
The return value is calculated as the number of bytes written
to the passed buffer.