### PR TITLE
ADBDEV-6062: Fix tablespace mapping during restore

### DIFF
--- a/src/command/restore/restore.c
+++ b/src/command/restore/restore.c
@@ -15,6 +15,7 @@ Restore Command
 #include "common/debug.h"
 #include "common/log.h"
 #include "common/regExp.h"
+#include "common/type/convert.h"
 #include "common/user.h"
 #include "config/config.h"
 #include "config/exec.h"
@@ -529,9 +530,10 @@ restoreManifestMap(Manifest *const manifest)
                     // Remap tablespace if a mapping was found
                     if (tablespacePath != NULL)
                     {
-                        // Append dbid to the path for Greenplum
+                        // We'll need to append dbid to the path for Greenplum. Currently, nothing really stores a correct dbid of
+                        // a segment that was used, so just retrieve the last folder as a segment number.
                         if (cfgOptionStrId(cfgOptFork) == CFGOPTVAL_FORK_GPDB)
-                            tablespacePath = strNewFmt("%s/%u", strZ(tablespacePath), manifestData(manifest)->pgId);
+                            tablespacePath = strNewFmt("%s/%d", strZ(tablespacePath), cvtZToInt(strBaseZ(target->path)));
 
                         LOG_INFO_FMT("map tablespace '%s' from '%s' to '%s'", strZ(target->name), strZ(target->path), strZ(tablespacePath));
 

--- a/src/command/restore/restore.c
+++ b/src/command/restore/restore.c
@@ -488,8 +488,6 @@ restoreManifestMap(Manifest *const manifest)
                     // Tablespace path without dbid
                     const String *tablespacePath = NULL;
 
-                    LOG_INFO_FMT("using tablespace '%s' in '%s'", strZ(target->name), strZ(target->path));
-
                     // Check for an individual mapping for this tablespace
                     if (tablespaceMap != NULL)
                     {
@@ -535,7 +533,7 @@ restoreManifestMap(Manifest *const manifest)
                         if (cfgOptionStrId(cfgOptFork) == CFGOPTVAL_FORK_GPDB)
                             tablespacePath = strNewFmt("%s/%u", strZ(tablespacePath), manifestData(manifest)->pgId);
 
-                        LOG_INFO_FMT("map tablespace '%s' to '%s'", strZ(target->name), strZ(tablespacePath));
+                        LOG_INFO_FMT("map tablespace '%s' from '%s' to '%s'", strZ(target->name), strZ(target->path), strZ(tablespacePath));
 
                         manifestTargetUpdate(manifest, target->name, tablespacePath, NULL);
                         manifestLinkUpdate(manifest, strNewFmt(MANIFEST_TARGET_PGDATA "/%s", strZ(target->name)), tablespacePath);

--- a/src/command/restore/restore.c
+++ b/src/command/restore/restore.c
@@ -532,15 +532,14 @@ restoreManifestMap(Manifest *const manifest)
                     if (tablespacePath != NULL)
                     {
                         // Append dbid to the path for Greenplum
-                        const String *const fixedTablespacePath =
-                            cfgOptionStrId(cfgOptFork) == CFGOPTVAL_FORK_GPDB ?
-                                strNewFmt("%s/%u", strZ(tablespacePath), manifestData(manifest)->pgId) : tablespacePath;
+                        if (cfgOptionStrId(cfgOptFork) == CFGOPTVAL_FORK_GPDB)
+                            tablespacePath = strNewFmt("%s/%u", strZ(tablespacePath), manifestData(manifest)->pgId);
 
-                        LOG_INFO_FMT("map tablespace '%s' to '%s'", strZ(target->name), strZ(fixedTablespacePath));
+                        LOG_INFO_FMT("map tablespace '%s' to '%s'", strZ(target->name), strZ(tablespacePath));
 
-                        manifestTargetUpdate(manifest, target->name, fixedTablespacePath, NULL);
+                        manifestTargetUpdate(manifest, target->name, tablespacePath, NULL);
                         manifestLinkUpdate(
-                            manifest, strNewFmt(MANIFEST_TARGET_PGDATA "/%s", strZ(target->name)), fixedTablespacePath);
+                            manifest, strNewFmt(MANIFEST_TARGET_PGDATA "/%s", strZ(target->name)), tablespacePath);
                     }
                 }
             }

--- a/src/command/restore/restore.c
+++ b/src/command/restore/restore.c
@@ -538,8 +538,7 @@ restoreManifestMap(Manifest *const manifest)
                         LOG_INFO_FMT("map tablespace '%s' to '%s'", strZ(target->name), strZ(tablespacePath));
 
                         manifestTargetUpdate(manifest, target->name, tablespacePath, NULL);
-                        manifestLinkUpdate(
-                            manifest, strNewFmt(MANIFEST_TARGET_PGDATA "/%s", strZ(target->name)), tablespacePath);
+                        manifestLinkUpdate(manifest, strNewFmt(MANIFEST_TARGET_PGDATA "/%s", strZ(target->name)), tablespacePath);
                     }
                 }
             }

--- a/test/src/module/command/restoreTest.c
+++ b/test/src/module/command/restoreTest.c
@@ -814,8 +814,6 @@ testRun(void)
         TEST_ERROR(
             restoreManifestMap(manifest), TablespaceMapError, "tablespace remapped by name 'ts2' and id 2 with different paths");
 
-        // Postgres tests first
-
         // Remap one tablespace using the id and another with the name
         argList = strLstNew();
         hrnCfgArgRawZ(argList, cfgOptStanza, "test1");
@@ -834,8 +832,8 @@ testRun(void)
             manifestLinkFind(manifest, STRDEF("pg_data/pg_tblspc/2"))->destination, "/2-2", "check tablespace 1 link");
 
         TEST_RESULT_LOG(
-            "P00   INFO: map tablespace 'pg_tblspc/1' from '/1' to '/1-2'\n"
-            "P00   INFO: map tablespace 'pg_tblspc/2' from '/2' to '/2-2'");
+            "P00   INFO: map tablespace 'pg_tblspc/1' to '/1-2'\n"
+            "P00   INFO: map tablespace 'pg_tblspc/2' to '/2-2'");
 
         // Remap a tablespace using just the id and map the rest with tablespace-map-all
         argList = strLstNew();
@@ -855,8 +853,8 @@ testRun(void)
             manifestLinkFind(manifest, STRDEF("pg_data/pg_tblspc/2"))->destination, "/2-3", "check tablespace 1 link");
 
         TEST_RESULT_LOG(
-            "P00   INFO: map tablespace 'pg_tblspc/1' from '/1-2' to '/all/1'\n"
-            "P00   INFO: map tablespace 'pg_tblspc/2' from '/2-2' to '/2-3'");
+            "P00   INFO: map tablespace 'pg_tblspc/1' to '/all/1'\n"
+            "P00   INFO: map tablespace 'pg_tblspc/2' to '/2-3'");
 
         // Remap all tablespaces with tablespace-map-all
         argList = strLstNew();
@@ -875,8 +873,8 @@ testRun(void)
             manifestLinkFind(manifest, STRDEF("pg_data/pg_tblspc/2"))->destination, "/all2/ts2", "check tablespace 1 link");
 
         TEST_RESULT_LOG(
-            "P00   INFO: map tablespace 'pg_tblspc/1' from '/all/1' to '/all2/1'\n"
-            "P00   INFO: map tablespace 'pg_tblspc/2' from '/2-3' to '/all2/ts2'");
+            "P00   INFO: map tablespace 'pg_tblspc/1' to '/all2/1'\n"
+            "P00   INFO: map tablespace 'pg_tblspc/2' to '/all2/ts2'");
 
         // Same tests, for Greenplum
 
@@ -915,8 +913,8 @@ testRun(void)
             manifestLinkFind(manifest, STRDEF("pg_data/pg_tblspc/gpdb_2"))->destination, "/gpdb_2-2/1", "check tablespace 2 link");
 
         TEST_RESULT_LOG(
-            "P00   INFO: map tablespace 'pg_tblspc/gpdb_1' from '/gpdb_1/0' to '/gpdb_1-2/0'\n"
-            "P00   INFO: map tablespace 'pg_tblspc/gpdb_2' from '/gpdb_2/1' to '/gpdb_2-2/1'");
+            "P00   INFO: map tablespace 'pg_tblspc/gpdb_1' to '/gpdb_1-2/0'\n"
+            "P00   INFO: map tablespace 'pg_tblspc/gpdb_2' to '/gpdb_2-2/1'");
 
         // Remap a tablespace using just the id and map the rest with tablespace-map-all
         argList = strLstNew();
@@ -938,8 +936,8 @@ testRun(void)
             manifestLinkFind(manifest, STRDEF("pg_data/pg_tblspc/gpdb_2"))->destination, "/gpdb_2-3/1", "check tablespace 2 link");
 
         TEST_RESULT_LOG(
-            "P00   INFO: map tablespace 'pg_tblspc/gpdb_1' from '/gpdb_1-2/0' to '/all/gpdb_1/0'\n"
-            "P00   INFO: map tablespace 'pg_tblspc/gpdb_2' from '/gpdb_2-2/1' to '/gpdb_2-3/1'");
+            "P00   INFO: map tablespace 'pg_tblspc/gpdb_1' to '/all/gpdb_1/0'\n"
+            "P00   INFO: map tablespace 'pg_tblspc/gpdb_2' to '/gpdb_2-3/1'");
 
         // Remap all tablespaces with tablespace-map-all
         argList = strLstNew();
@@ -960,30 +958,8 @@ testRun(void)
             manifestLinkFind(manifest, STRDEF("pg_data/pg_tblspc/gpdb_2"))->destination, "/all2/gpdb_ts2/1", "check tablespace 2 link");
 
         TEST_RESULT_LOG(
-            "P00   INFO: map tablespace 'pg_tblspc/gpdb_1' from '/all/gpdb_1/0' to '/all2/gpdb_1/0'\n"
-            "P00   INFO: map tablespace 'pg_tblspc/gpdb_2' from '/gpdb_2-3/1' to '/all2/gpdb_ts2/1'");
-
-        // -------------------------------------------------------------------------------------------------------------------------
-
-        TEST_TITLE("error on invalid dbid folder for greenplum");
-
-        HRN_MANIFEST_TARGET_ADD(
-            manifest, .name = "pg_tblspc/gpdb_3", .path = "/gpdb_3/not_a_number", .tablespaceId = 5, .tablespaceName = "not_a_number",
-            .type = manifestTargetTypeLink);
-        HRN_MANIFEST_LINK_ADD(manifest, .name = "pg_data/pg_tblspc/gpdb_3", .destination = "/gpdb_3/not_a_number");
-
-        argList = strLstNew();
-        hrnCfgArgRawZ(argList, cfgOptStanza, "test1");
-        hrnCfgArgRaw(argList, cfgOptRepoPath, repoPath);
-        hrnCfgArgRaw(argList, cfgOptPgPath, pgPath);
-        hrnCfgArgRawZ(argList, cfgOptTablespaceMap, "not_a_number=/gpdb_3-2");
-
-        hrnCfgArgRawZ(argList, cfgOptFork, "GPDB");
-        HRN_CFG_LOAD(cfgCmdRestore, argList);
-
-        TEST_ERROR(
-            restoreManifestMap(manifest), TablespaceMapError,
-            "greenplum-specific tablespace path '/gpdb_3/not_a_number' contains invalid dbid directory 'not_a_number'");
+            "P00   INFO: map tablespace 'pg_tblspc/gpdb_1' to '/all2/gpdb_1/0'\n"
+            "P00   INFO: map tablespace 'pg_tblspc/gpdb_2' to '/all2/gpdb_ts2/1'");
 
         // -------------------------------------------------------------------------------------------------------------------------
         TEST_TITLE("error on invalid link");

--- a/test/src/module/command/restoreTest.c
+++ b/test/src/module/command/restoreTest.c
@@ -821,6 +821,8 @@ testRun(void)
         hrnCfgArgRaw(argList, cfgOptPgPath, pgPath);
         hrnCfgArgRawZ(argList, cfgOptTablespaceMap, "1=/1-2");
         hrnCfgArgRawZ(argList, cfgOptTablespaceMap, "ts2=/2-2");
+
+        // Postgres
         HRN_CFG_LOAD(cfgCmdRestore, argList);
 
         TEST_RESULT_VOID(restoreManifestMap(manifest), "remap tablespaces");
@@ -832,8 +834,30 @@ testRun(void)
             manifestLinkFind(manifest, STRDEF("pg_data/pg_tblspc/2"))->destination, "/2-2", "check tablespace 1 link");
 
         TEST_RESULT_LOG(
+            "P00   INFO: using tablespace 'pg_tblspc/1' in '/1'\n"
+            "P00   INFO: using tablespace 'pg_tblspc/2' in '/2'\n"
+            "P00   INFO: using tablespace 'pg_tblspc/1' in '/1'\n"
             "P00   INFO: map tablespace 'pg_tblspc/1' to '/1-2'\n"
+            "P00   INFO: using tablespace 'pg_tblspc/2' in '/2'\n"
             "P00   INFO: map tablespace 'pg_tblspc/2' to '/2-2'");
+
+        // Greenplum
+        hrnCfgArgRawZ(argList, cfgOptFork, "GPDB");
+        HRN_CFG_LOAD(cfgCmdRestore, argList);
+
+        TEST_RESULT_VOID(restoreManifestMap(manifest), "remap tablespaces");
+        TEST_RESULT_STR_Z(manifestTargetFind(manifest, STRDEF("pg_tblspc/1"))->path, "/1-2/0", "check tablespace 1 target");
+        TEST_RESULT_STR_Z(
+            manifestLinkFind(manifest, STRDEF("pg_data/pg_tblspc/1"))->destination, "/1-2/0", "check tablespace 1 link");
+        TEST_RESULT_STR_Z(manifestTargetFind(manifest, STRDEF("pg_tblspc/2"))->path, "/2-2/0", "check tablespace 1 target");
+        TEST_RESULT_STR_Z(
+            manifestLinkFind(manifest, STRDEF("pg_data/pg_tblspc/2"))->destination, "/2-2/0", "check tablespace 1 link");
+
+        TEST_RESULT_LOG(
+            "P00   INFO: using tablespace 'pg_tblspc/1' in '/1-2'\n"
+            "P00   INFO: map tablespace 'pg_tblspc/1' to '/1-2/0'\n"
+            "P00   INFO: using tablespace 'pg_tblspc/2' in '/2-2'\n"
+            "P00   INFO: map tablespace 'pg_tblspc/2' to '/2-2/0'");
 
         // Remap a tablespace using just the id and map the rest with tablespace-map-all
         argList = strLstNew();
@@ -842,6 +866,8 @@ testRun(void)
         hrnCfgArgRaw(argList, cfgOptPgPath, pgPath);
         hrnCfgArgRawZ(argList, cfgOptTablespaceMap, "2=/2-3");
         hrnCfgArgRawZ(argList, cfgOptTablespaceMapAll, "/all");
+
+        // Postgres
         HRN_CFG_LOAD(cfgCmdRestore, argList);
 
         TEST_RESULT_VOID(restoreManifestMap(manifest), "remap tablespaces");
@@ -853,8 +879,28 @@ testRun(void)
             manifestLinkFind(manifest, STRDEF("pg_data/pg_tblspc/2"))->destination, "/2-3", "check tablespace 1 link");
 
         TEST_RESULT_LOG(
+            "P00   INFO: using tablespace 'pg_tblspc/1' in '/1-2/0'\n"
             "P00   INFO: map tablespace 'pg_tblspc/1' to '/all/1'\n"
+            "P00   INFO: using tablespace 'pg_tblspc/2' in '/2-2/0'\n"
             "P00   INFO: map tablespace 'pg_tblspc/2' to '/2-3'");
+
+        // Greenplum
+        hrnCfgArgRawZ(argList, cfgOptFork, "GPDB");
+        HRN_CFG_LOAD(cfgCmdRestore, argList);
+
+        TEST_RESULT_VOID(restoreManifestMap(manifest), "remap tablespaces");
+        TEST_RESULT_STR_Z(manifestTargetFind(manifest, STRDEF("pg_tblspc/1"))->path, "/all/1/0", "check tablespace 1 target");
+        TEST_RESULT_STR_Z(
+            manifestLinkFind(manifest, STRDEF("pg_data/pg_tblspc/1"))->destination, "/all/1/0", "check tablespace 1 link");
+        TEST_RESULT_STR_Z(manifestTargetFind(manifest, STRDEF("pg_tblspc/2"))->path, "/2-3/0", "check tablespace 1 target");
+        TEST_RESULT_STR_Z(
+            manifestLinkFind(manifest, STRDEF("pg_data/pg_tblspc/2"))->destination, "/2-3/0", "check tablespace 1 link");
+
+        TEST_RESULT_LOG(
+            "P00   INFO: using tablespace 'pg_tblspc/1' in '/all/1'\n"
+            "P00   INFO: map tablespace 'pg_tblspc/1' to '/all/1/0'\n"
+            "P00   INFO: using tablespace 'pg_tblspc/2' in '/2-3'\n"
+            "P00   INFO: map tablespace 'pg_tblspc/2' to '/2-3/0'");
 
         // Remap all tablespaces with tablespace-map-all
         argList = strLstNew();
@@ -862,6 +908,8 @@ testRun(void)
         hrnCfgArgRaw(argList, cfgOptRepoPath, repoPath);
         hrnCfgArgRaw(argList, cfgOptPgPath, pgPath);
         hrnCfgArgRawZ(argList, cfgOptTablespaceMapAll, "/all2");
+
+        // Postgres
         HRN_CFG_LOAD(cfgCmdRestore, argList);
 
         TEST_RESULT_VOID(restoreManifestMap(manifest), "remap tablespaces");
@@ -873,8 +921,28 @@ testRun(void)
             manifestLinkFind(manifest, STRDEF("pg_data/pg_tblspc/2"))->destination, "/all2/ts2", "check tablespace 1 link");
 
         TEST_RESULT_LOG(
+            "P00   INFO: using tablespace 'pg_tblspc/1' in '/all/1/0'\n"
             "P00   INFO: map tablespace 'pg_tblspc/1' to '/all2/1'\n"
+            "P00   INFO: using tablespace 'pg_tblspc/2' in '/2-3/0'\n"
             "P00   INFO: map tablespace 'pg_tblspc/2' to '/all2/ts2'");
+
+        // Greenplum
+        hrnCfgArgRawZ(argList, cfgOptFork, "GPDB");
+        HRN_CFG_LOAD(cfgCmdRestore, argList);
+
+        TEST_RESULT_VOID(restoreManifestMap(manifest), "remap tablespaces");
+        TEST_RESULT_STR_Z(manifestTargetFind(manifest, STRDEF("pg_tblspc/1"))->path, "/all2/1/0", "check tablespace 1 target");
+        TEST_RESULT_STR_Z(
+            manifestLinkFind(manifest, STRDEF("pg_data/pg_tblspc/1"))->destination, "/all2/1/0", "check tablespace 1 link");
+        TEST_RESULT_STR_Z(manifestTargetFind(manifest, STRDEF("pg_tblspc/2"))->path, "/all2/ts2/0", "check tablespace 1 target");
+        TEST_RESULT_STR_Z(
+            manifestLinkFind(manifest, STRDEF("pg_data/pg_tblspc/2"))->destination, "/all2/ts2/0", "check tablespace 1 link");
+
+        TEST_RESULT_LOG(
+            "P00   INFO: using tablespace 'pg_tblspc/1' in '/all2/1'\n"
+            "P00   INFO: map tablespace 'pg_tblspc/1' to '/all2/1/0'\n"
+            "P00   INFO: using tablespace 'pg_tblspc/2' in '/all2/ts2'\n"
+            "P00   INFO: map tablespace 'pg_tblspc/2' to '/all2/ts2/0'");
 
         // -------------------------------------------------------------------------------------------------------------------------
         TEST_TITLE("error on invalid link");

--- a/test/src/module/command/restoreTest.c
+++ b/test/src/module/command/restoreTest.c
@@ -834,12 +834,8 @@ testRun(void)
             manifestLinkFind(manifest, STRDEF("pg_data/pg_tblspc/2"))->destination, "/2-2", "check tablespace 1 link");
 
         TEST_RESULT_LOG(
-            "P00   INFO: using tablespace 'pg_tblspc/1' in '/1'\n"
-            "P00   INFO: using tablespace 'pg_tblspc/2' in '/2'\n"
-            "P00   INFO: using tablespace 'pg_tblspc/1' in '/1'\n"
-            "P00   INFO: map tablespace 'pg_tblspc/1' to '/1-2'\n"
-            "P00   INFO: using tablespace 'pg_tblspc/2' in '/2'\n"
-            "P00   INFO: map tablespace 'pg_tblspc/2' to '/2-2'");
+            "P00   INFO: map tablespace 'pg_tblspc/1' from '/1' to '/1-2'\n"
+            "P00   INFO: map tablespace 'pg_tblspc/2' from '/2' to '/2-2'");
 
         // Greenplum
         hrnCfgArgRawZ(argList, cfgOptFork, "GPDB");
@@ -854,10 +850,8 @@ testRun(void)
             manifestLinkFind(manifest, STRDEF("pg_data/pg_tblspc/2"))->destination, "/2-2/0", "check tablespace 1 link");
 
         TEST_RESULT_LOG(
-            "P00   INFO: using tablespace 'pg_tblspc/1' in '/1-2'\n"
-            "P00   INFO: map tablespace 'pg_tblspc/1' to '/1-2/0'\n"
-            "P00   INFO: using tablespace 'pg_tblspc/2' in '/2-2'\n"
-            "P00   INFO: map tablespace 'pg_tblspc/2' to '/2-2/0'");
+            "P00   INFO: map tablespace 'pg_tblspc/1' from '/1-2' to '/1-2/0'\n"
+            "P00   INFO: map tablespace 'pg_tblspc/2' from '/2-2' to '/2-2/0'");
 
         // Remap a tablespace using just the id and map the rest with tablespace-map-all
         argList = strLstNew();
@@ -879,10 +873,8 @@ testRun(void)
             manifestLinkFind(manifest, STRDEF("pg_data/pg_tblspc/2"))->destination, "/2-3", "check tablespace 1 link");
 
         TEST_RESULT_LOG(
-            "P00   INFO: using tablespace 'pg_tblspc/1' in '/1-2/0'\n"
-            "P00   INFO: map tablespace 'pg_tblspc/1' to '/all/1'\n"
-            "P00   INFO: using tablespace 'pg_tblspc/2' in '/2-2/0'\n"
-            "P00   INFO: map tablespace 'pg_tblspc/2' to '/2-3'");
+            "P00   INFO: map tablespace 'pg_tblspc/1' from '/1-2/0' to '/all/1'\n"
+            "P00   INFO: map tablespace 'pg_tblspc/2' from '/2-2/0' to '/2-3'");
 
         // Greenplum
         hrnCfgArgRawZ(argList, cfgOptFork, "GPDB");
@@ -897,10 +889,8 @@ testRun(void)
             manifestLinkFind(manifest, STRDEF("pg_data/pg_tblspc/2"))->destination, "/2-3/0", "check tablespace 1 link");
 
         TEST_RESULT_LOG(
-            "P00   INFO: using tablespace 'pg_tblspc/1' in '/all/1'\n"
-            "P00   INFO: map tablespace 'pg_tblspc/1' to '/all/1/0'\n"
-            "P00   INFO: using tablespace 'pg_tblspc/2' in '/2-3'\n"
-            "P00   INFO: map tablespace 'pg_tblspc/2' to '/2-3/0'");
+            "P00   INFO: map tablespace 'pg_tblspc/1' from '/all/1' to '/all/1/0'\n"
+            "P00   INFO: map tablespace 'pg_tblspc/2' from '/2-3' to '/2-3/0'");
 
         // Remap all tablespaces with tablespace-map-all
         argList = strLstNew();
@@ -921,10 +911,8 @@ testRun(void)
             manifestLinkFind(manifest, STRDEF("pg_data/pg_tblspc/2"))->destination, "/all2/ts2", "check tablespace 1 link");
 
         TEST_RESULT_LOG(
-            "P00   INFO: using tablespace 'pg_tblspc/1' in '/all/1/0'\n"
-            "P00   INFO: map tablespace 'pg_tblspc/1' to '/all2/1'\n"
-            "P00   INFO: using tablespace 'pg_tblspc/2' in '/2-3/0'\n"
-            "P00   INFO: map tablespace 'pg_tblspc/2' to '/all2/ts2'");
+            "P00   INFO: map tablespace 'pg_tblspc/1' from '/all/1/0' to '/all2/1'\n"
+            "P00   INFO: map tablespace 'pg_tblspc/2' from '/2-3/0' to '/all2/ts2'");
 
         // Greenplum
         hrnCfgArgRawZ(argList, cfgOptFork, "GPDB");
@@ -939,10 +927,8 @@ testRun(void)
             manifestLinkFind(manifest, STRDEF("pg_data/pg_tblspc/2"))->destination, "/all2/ts2/0", "check tablespace 1 link");
 
         TEST_RESULT_LOG(
-            "P00   INFO: using tablespace 'pg_tblspc/1' in '/all2/1'\n"
-            "P00   INFO: map tablespace 'pg_tblspc/1' to '/all2/1/0'\n"
-            "P00   INFO: using tablespace 'pg_tblspc/2' in '/all2/ts2'\n"
-            "P00   INFO: map tablespace 'pg_tblspc/2' to '/all2/ts2/0'");
+            "P00   INFO: map tablespace 'pg_tblspc/1' from '/all2/1' to '/all2/1/0'\n"
+            "P00   INFO: map tablespace 'pg_tblspc/2' from '/all2/ts2' to '/all2/ts2/0'");
 
         // -------------------------------------------------------------------------------------------------------------------------
         TEST_TITLE("error on invalid link");

--- a/test/src/module/command/restoreTest.c
+++ b/test/src/module/command/restoreTest.c
@@ -792,6 +792,7 @@ testRun(void)
 
         TEST_ERROR(restoreManifestMap(manifest), TablespaceMapError, "unable to remap invalid tablespace 'bogus'");
 
+        // Add some tablespaces
         HRN_MANIFEST_TARGET_ADD(
             manifest, .name = "pg_tblspc/1", .path = "/1", .tablespaceId = 1, .tablespaceName = "1",
             .type = manifestTargetTypeLink);
@@ -822,7 +823,6 @@ testRun(void)
         hrnCfgArgRaw(argList, cfgOptPgPath, pgPath);
         hrnCfgArgRawZ(argList, cfgOptTablespaceMap, "1=/1-2");
         hrnCfgArgRawZ(argList, cfgOptTablespaceMap, "ts2=/2-2");
-
         HRN_CFG_LOAD(cfgCmdRestore, argList);
 
         TEST_RESULT_VOID(restoreManifestMap(manifest), "remap tablespaces");
@@ -844,7 +844,6 @@ testRun(void)
         hrnCfgArgRaw(argList, cfgOptPgPath, pgPath);
         hrnCfgArgRawZ(argList, cfgOptTablespaceMap, "2=/2-3");
         hrnCfgArgRawZ(argList, cfgOptTablespaceMapAll, "/all");
-
         HRN_CFG_LOAD(cfgCmdRestore, argList);
 
         TEST_RESULT_VOID(restoreManifestMap(manifest), "remap tablespaces");
@@ -865,7 +864,6 @@ testRun(void)
         hrnCfgArgRaw(argList, cfgOptRepoPath, repoPath);
         hrnCfgArgRaw(argList, cfgOptPgPath, pgPath);
         hrnCfgArgRawZ(argList, cfgOptTablespaceMapAll, "/all2");
-
         HRN_CFG_LOAD(cfgCmdRestore, argList);
 
         TEST_RESULT_VOID(restoreManifestMap(manifest), "remap tablespaces");

--- a/test/src/module/command/restoreTest.c
+++ b/test/src/module/command/restoreTest.c
@@ -905,10 +905,12 @@ testRun(void)
         HRN_CFG_LOAD(cfgCmdRestore, argList);
 
         TEST_RESULT_VOID(restoreManifestMap(manifest), "remap tablespaces");
-        TEST_RESULT_STR_Z(manifestTargetFind(manifest, STRDEF("pg_tblspc/gpdb_1"))->path, "/gpdb_1-2/0", "check tablespace 1 target");
+        TEST_RESULT_STR_Z(
+            manifestTargetFind(manifest, STRDEF("pg_tblspc/gpdb_1"))->path, "/gpdb_1-2/0", "check tablespace 1 target");
         TEST_RESULT_STR_Z(
             manifestLinkFind(manifest, STRDEF("pg_data/pg_tblspc/gpdb_1"))->destination, "/gpdb_1-2/0", "check tablespace 1 link");
-        TEST_RESULT_STR_Z(manifestTargetFind(manifest, STRDEF("pg_tblspc/gpdb_2"))->path, "/gpdb_2-2/1", "check tablespace 2 target");
+        TEST_RESULT_STR_Z(
+            manifestTargetFind(manifest, STRDEF("pg_tblspc/gpdb_2"))->path, "/gpdb_2-2/1", "check tablespace 2 target");
         TEST_RESULT_STR_Z(
             manifestLinkFind(manifest, STRDEF("pg_data/pg_tblspc/gpdb_2"))->destination, "/gpdb_2-2/1", "check tablespace 2 link");
 
@@ -928,10 +930,13 @@ testRun(void)
         HRN_CFG_LOAD(cfgCmdRestore, argList);
 
         TEST_RESULT_VOID(restoreManifestMap(manifest), "remap tablespaces");
-        TEST_RESULT_STR_Z(manifestTargetFind(manifest, STRDEF("pg_tblspc/gpdb_1"))->path, "/all/gpdb_1/0", "check tablespace 1 target");
         TEST_RESULT_STR_Z(
-            manifestLinkFind(manifest, STRDEF("pg_data/pg_tblspc/gpdb_1"))->destination, "/all/gpdb_1/0", "check tablespace 1 link");
-        TEST_RESULT_STR_Z(manifestTargetFind(manifest, STRDEF("pg_tblspc/gpdb_2"))->path, "/gpdb_2-3/1", "check tablespace 2 target");
+            manifestTargetFind(manifest, STRDEF("pg_tblspc/gpdb_1"))->path, "/all/gpdb_1/0", "check tablespace 1 target");
+        TEST_RESULT_STR_Z(
+            manifestLinkFind(
+                manifest, STRDEF("pg_data/pg_tblspc/gpdb_1"))->destination, "/all/gpdb_1/0", "check tablespace 1 link");
+        TEST_RESULT_STR_Z(
+            manifestTargetFind(manifest, STRDEF("pg_tblspc/gpdb_2"))->path, "/gpdb_2-3/1", "check tablespace 2 target");
         TEST_RESULT_STR_Z(
             manifestLinkFind(manifest, STRDEF("pg_data/pg_tblspc/gpdb_2"))->destination, "/gpdb_2-3/1", "check tablespace 2 link");
 
@@ -950,12 +955,16 @@ testRun(void)
         HRN_CFG_LOAD(cfgCmdRestore, argList);
 
         TEST_RESULT_VOID(restoreManifestMap(manifest), "remap tablespaces");
-        TEST_RESULT_STR_Z(manifestTargetFind(manifest, STRDEF("pg_tblspc/gpdb_1"))->path, "/all2/gpdb_1/0", "check tablespace 1 target");
         TEST_RESULT_STR_Z(
-            manifestLinkFind(manifest, STRDEF("pg_data/pg_tblspc/gpdb_1"))->destination, "/all2/gpdb_1/0", "check tablespace 1 link");
-        TEST_RESULT_STR_Z(manifestTargetFind(manifest, STRDEF("pg_tblspc/gpdb_2"))->path, "/all2/gpdb_ts2/1", "check tablespace 2 target");
+            manifestTargetFind(manifest, STRDEF("pg_tblspc/gpdb_1"))->path, "/all2/gpdb_1/0", "check tablespace 1 target");
         TEST_RESULT_STR_Z(
-            manifestLinkFind(manifest, STRDEF("pg_data/pg_tblspc/gpdb_2"))->destination, "/all2/gpdb_ts2/1", "check tablespace 2 link");
+            manifestLinkFind(
+                manifest, STRDEF("pg_data/pg_tblspc/gpdb_1"))->destination, "/all2/gpdb_1/0", "check tablespace 1 link");
+        TEST_RESULT_STR_Z(
+            manifestTargetFind(manifest, STRDEF("pg_tblspc/gpdb_2"))->path, "/all2/gpdb_ts2/1", "check tablespace 2 target");
+        TEST_RESULT_STR_Z(
+            manifestLinkFind(
+                manifest, STRDEF("pg_data/pg_tblspc/gpdb_2"))->destination, "/all2/gpdb_ts2/1", "check tablespace 2 link");
 
         TEST_RESULT_LOG(
             "P00   INFO: map tablespace 'pg_tblspc/gpdb_1' to '/all2/gpdb_1/0'\n"


### PR DESCRIPTION
Fix tablespace mapping during restore

Previously, if --tablespace-map/--tablespace-map-all flag was used to restore a
GPDB segment's data, the symlink inside pg_tblspc for remapped tablespaces was
incorrectly pointing to \<tablespace_dir\>/ instead of
\<tablespace_dir\>/\<dbid\>.

The dbid part is actually never stored anywhere in the manifest or stanza.
Instead, tablespace path is put as an absolute path with the dbid as the base
folder. So the way used to obtain dbid is to get the basename of the
GPDB-specific tablespace path.

This patch adds GPDB-only logic for tablespace remapping to include dbid part
back into the path of restored tablespaces.