### PR TITLE
Add the --filter option for the restore command

### DIFF
--- a/src/command/restore/restore.c
+++ b/src/command/restore/restore.c
@@ -2075,12 +2075,12 @@ restoreProcessQueue(const Manifest *const manifest, List **const queueList)
             const ManifestFile file = manifestFileUnpack(manifest, filePack);
 
             Oid dbNode, relNode;
-            if (sscanf(strZ(file.name), "pg_data/base/%u/%u", &dbNode, &relNode) == 2)
+            if (sscanf(strZ(file.name), MANIFEST_TARGET_PGDATA "/" PG_PATH_BASE "/%u/%u", &dbNode, &relNode) == 2)
             {
                 if (!isRelationNeeded(dbNode, DEFAULTTABLESPACE_OID, relNode))
                     continue;
             }
-            else if (strBeginsWithZ(file.name, "pg_tblspc/"))
+            else if (strBeginsWithZ(file.name, MANIFEST_TARGET_PGTBLSPC "/"))
             {
                 StringList *lst = strLstNewSplitZ(file.name, "/");
                 if (strLstSize(lst) == 5)

--- a/src/command/restore/restore.c
+++ b/src/command/restore/restore.c
@@ -2502,6 +2502,12 @@ cmdRestore(void)
             strNewFmt(STORAGE_REPO_BACKUP "/%s/" BACKUP_MANIFEST_FILE, strZ(backupData.backupSet)), backupData.repoCipherType,
             backupData.backupCipherPass);
 
+        if (cfgOptionTest(cfgOptFilter) &&
+            (cfgOptionStrId(cfgOptFork) != CFGOPTVAL_FORK_GPDB || manifestData(jobData.manifest)->pgVersion != PG_VERSION_94))
+        {
+            THROW(OptionInvalidError, "option '" CFGOPT_FILTER "' is supported on GPDB 6 only");
+        }
+
         // Remotes (if any) are no longer needed since the rest of the repository reads will be done by the local processes
         protocolFree();
 

--- a/src/command/restore/restore.c
+++ b/src/command/restore/restore.c
@@ -2075,11 +2075,13 @@ restoreProcessQueue(const Manifest *const manifest, List **const queueList)
             const ManifestFile file = manifestFileUnpack(manifest, filePack);
 
             Oid dbNode, relNode;
+            // If this file is located in the default tablespace
             if (sscanf(strZ(file.name), MANIFEST_TARGET_PGDATA "/" PG_PATH_BASE "/%u/%u", &dbNode, &relNode) == 2)
             {
                 if (!isRelationNeeded(dbNode, DEFAULTTABLESPACE_OID, relNode))
                     continue;
             }
+            // If this file is located in a non-built-in tablespace
             else if (strBeginsWithZ(file.name, MANIFEST_TARGET_PGTBLSPC "/"))
             {
                 StringList *lst = strLstNewSplitZ(file.name, "/");

--- a/src/command/restore/restore.c
+++ b/src/command/restore/restore.c
@@ -2079,12 +2079,11 @@ restoreProcessQueue(const Manifest *const manifest, List **const queueList)
             {
                 Oid dbNode, relNode;
                 Oid spcNode = DEFAULTTABLESPACE_OID;
-                char tsId[32];
                 if (
                     // If this file is located in the default tablespace
                     sscanf(strZ(file.name), MANIFEST_TARGET_PGDATA "/" PG_PATH_BASE "/%u/%u", &dbNode, &relNode) == 2 ||
                     // If this file is located in a non-built-in tablespace
-                    sscanf(strZ(file.name), MANIFEST_TARGET_PGTBLSPC "/%u/%31[^/]/%u/%u", &spcNode, tsId, &dbNode, &relNode) == 4)
+                    sscanf(strZ(file.name), MANIFEST_TARGET_PGTBLSPC "/%u/%*[^/]/%u/%u", &spcNode, &dbNode, &relNode) == 3)
                 {
                     if (!isRelationNeeded(dbNode, spcNode, relNode))
                         continue;

--- a/src/command/restore/restore.c
+++ b/src/command/restore/restore.c
@@ -2083,7 +2083,7 @@ restoreProcessQueue(const Manifest *const manifest, List **const queueList)
                 if (
                     // If this file is located in the default tablespace
                     sscanf(strZ(file.name), MANIFEST_TARGET_PGDATA "/" PG_PATH_BASE "/%u/%u", &dbNode, &relNode) == 2 ||
-	                // If this file is located in a non-built-in tablespace
+                    // If this file is located in a non-built-in tablespace
                     sscanf(strZ(file.name), MANIFEST_TARGET_PGTBLSPC "/%u/%31[^/]/%u/%u", &spcNode, tsId, &dbNode, &relNode) == 4)
                 {
                     if (!isRelationNeeded(dbNode, spcNode, relNode))

--- a/src/common/partialRestore.c
+++ b/src/common/partialRestore.c
@@ -111,7 +111,7 @@ buildFilterList(JsonRead *const json)
     return lstSort(result, sortOrderAsc);
 }
 
-FN_EXTERN __attribute__((unused)) bool
+FN_EXTERN bool
 isRelationNeeded(const Oid dbNode, const Oid spcNode, const Oid relNode)
 {
     if (!cfgOptionTest(cfgOptFilter))

--- a/test/src/module/command/restoreTest.c
+++ b/test/src/module/command/restoreTest.c
@@ -3411,6 +3411,7 @@ testRun(void)
         HRN_STORAGE_PUT_EMPTY(storageTest, "ts/GPDB_6_301908232/16416/20001_fsm");
         HRN_STORAGE_PUT_EMPTY(storageTest, "ts/GPDB_6_301908232/16416/20001_vm");
         HRN_STORAGE_PUT_EMPTY(storageTest, "ts/GPDB_6_301908232/16416/" PG_FILE_PGVERSION);
+        HRN_STORAGE_PUT_EMPTY(storageTest, "ts/GPDB_6_301908232/16416/pg_filenode.map");
         HRN_STORAGE_PUT_EMPTY(storageTest, "ts/GPDB_6_301908232/invalidDir/20003");
         HRN_STORAGE_PUT_EMPTY(storageTest, "ts/GPDB_6_301908232/invalidFile");
         HRN_STORAGE_PATH_CREATE(storagePgWrite(), PG_PATH_PGTBLSPC);
@@ -3505,6 +3506,7 @@ testRun(void)
             "16416/20000_fsm\n"
             "16416/20000_vm\n"
             "16416/" PG_FILE_PGVERSION "\n"
+            "16416/pg_filenode.map\n"
             "invalidDir/\n"
             "invalidDir/20003\n"
             "invalidFile\n",

--- a/test/src/module/command/restoreTest.c
+++ b/test/src/module/command/restoreTest.c
@@ -3414,8 +3414,6 @@ testRun(void)
         HRN_STORAGE_PUT_EMPTY(storageTest, "ts/GPDB_6_301908232/16416/20001_vm");
         HRN_STORAGE_PUT_EMPTY(storageTest, "ts/GPDB_6_301908232/16416/" PG_FILE_PGVERSION);
         HRN_STORAGE_PUT_EMPTY(storageTest, "ts/GPDB_6_301908232/16416/pg_filenode.map");
-        HRN_STORAGE_PUT_EMPTY(storageTest, "ts/GPDB_6_301908232/invalidDir/20003");
-        HRN_STORAGE_PUT_EMPTY(storageTest, "ts/GPDB_6_301908232/invalidFile");
         HRN_STORAGE_PATH_CREATE(storagePgWrite(), PG_PATH_PGTBLSPC);
         THROW_ON_SYS_ERROR(
             symlink(TEST_PATH "/ts", zNewFmt("%s/" PG_PATH_PGTBLSPC "/16415", strZ(pgPath))) == -1,
@@ -3510,10 +3508,7 @@ testRun(void)
             "16416/20000_fsm\n"
             "16416/20000_vm\n"
             "16416/" PG_FILE_PGVERSION "\n"
-            "16416/pg_filenode.map\n"
-            "invalidDir/\n"
-            "invalidDir/20003\n"
-            "invalidFile\n",
+            "16416/pg_filenode.map\n",
             .level = storageInfoLevelType);
 
         // -------------------------------------------------------------------------------------------------------------------------

--- a/test/src/module/command/restoreTest.c
+++ b/test/src/module/command/restoreTest.c
@@ -3411,6 +3411,8 @@ testRun(void)
         HRN_STORAGE_PUT_EMPTY(storageTest, "ts/GPDB_6_301908232/16416/20001_fsm");
         HRN_STORAGE_PUT_EMPTY(storageTest, "ts/GPDB_6_301908232/16416/20001_vm");
         HRN_STORAGE_PUT_EMPTY(storageTest, "ts/GPDB_6_301908232/16416/" PG_FILE_PGVERSION);
+        HRN_STORAGE_PUT_EMPTY(storageTest, "ts/GPDB_6_301908232/invalidDir/20003");
+        HRN_STORAGE_PUT_EMPTY(storageTest, "ts/GPDB_6_301908232/invalidFile");
         HRN_STORAGE_PATH_CREATE(storagePgWrite(), PG_PATH_PGTBLSPC);
         THROW_ON_SYS_ERROR(
             symlink(TEST_PATH "/ts", zNewFmt("%s/" PG_PATH_PGTBLSPC "/16415", strZ(pgPath))) == -1,
@@ -3502,7 +3504,10 @@ testRun(void)
             "16416/20000\n"
             "16416/20000_fsm\n"
             "16416/20000_vm\n"
-            "16416/" PG_FILE_PGVERSION "\n",
+            "16416/" PG_FILE_PGVERSION "\n"
+            "invalidDir/\n"
+            "invalidDir/20003\n"
+            "invalidFile\n",
             .level = storageInfoLevelType);
 
         // -------------------------------------------------------------------------------------------------------------------------

--- a/test/src/module/command/restoreTest.c
+++ b/test/src/module/command/restoreTest.c
@@ -3392,6 +3392,109 @@ testRun(void)
 
         // Check that file was restored to full size with a partial write
         TEST_RESULT_LOG_EMPTY_OR_CONTAINS(", bi 128KB/256KB, ");
+        harnessLogLevelSet(logLevelWarn);
+
+        // -------------------------------------------------------------------------------------------------------------------------
+        TEST_TITLE("restore filter");
+
+        HRN_STORAGE_PUT_EMPTY(storagePgWrite(), PG_PATH_BASE "/1/40044");
+        HRN_STORAGE_PUT_EMPTY(storagePgWrite(), PG_PATH_BASE "/1/40044_fsm");
+        HRN_STORAGE_PUT_EMPTY(storagePgWrite(), PG_PATH_BASE "/1/40044_vm");
+        HRN_STORAGE_PUT_EMPTY(storagePgWrite(), PG_PATH_BASE "/1/40045");
+        HRN_STORAGE_PUT_EMPTY(storagePgWrite(), PG_PATH_BASE "/1/40045_fsm");
+        HRN_STORAGE_PUT_EMPTY(storagePgWrite(), PG_PATH_BASE "/1/40045_vm");
+        HRN_STORAGE_PUT_EMPTY(storageTest, "ts/PG_15_202209061/16416/20000");
+        HRN_STORAGE_PUT_EMPTY(storageTest, "ts/PG_15_202209061/16416/20000_fsm");
+        HRN_STORAGE_PUT_EMPTY(storageTest, "ts/PG_15_202209061/16416/20000_vm");
+        HRN_STORAGE_PUT_EMPTY(storageTest, "ts/PG_15_202209061/16416/20001");
+        HRN_STORAGE_PUT_EMPTY(storageTest, "ts/PG_15_202209061/16416/20001_fsm");
+        HRN_STORAGE_PUT_EMPTY(storageTest, "ts/PG_15_202209061/16416/20001_vm");
+        HRN_STORAGE_PUT_EMPTY(storageTest, "ts/PG_15_202209061/16416/" PG_FILE_PGVERSION);
+        HRN_STORAGE_PATH_CREATE(storagePgWrite(), PG_PATH_PGTBLSPC);
+        THROW_ON_SYS_ERROR(
+            symlink(TEST_PATH "/ts", zNewFmt("%s/" PG_PATH_PGTBLSPC "/16415", strZ(pgPath))) == -1,
+            FileOpenError, "unable to create symlink");
+
+        // Backup
+        argList = strLstNew();
+        hrnCfgArgRawZ(argList, cfgOptStanza, "test1");
+        hrnCfgArgRaw(argList, cfgOptRepoPath, repoPath);
+        hrnCfgArgRaw(argList, cfgOptPgPath, pgPath);
+        hrnCfgArgRawZ(argList, cfgOptRepoRetentionFull, "1");
+        hrnCfgArgRawStrId(argList, cfgOptType, backupTypeFull);
+        hrnCfgArgRawBool(argList, cfgOptOnline, false);
+        hrnCfgArgRawZ(argList, cfgOptRepoCipherType, "aes-256-cbc");
+        hrnCfgEnvRawZ(cfgOptRepoCipherPass, TEST_CIPHER_PASS);
+        HRN_CFG_LOAD(cfgCmdBackup, argList);
+
+        TEST_RESULT_VOID(hrnCmdBackup(), "backup");
+
+        HRN_STORAGE_PATH_REMOVE(storagePgWrite(), NULL, .recurse = true);
+        HRN_STORAGE_PATH_REMOVE(storageTest, "ts/PG_15_202209061", .recurse = true);
+
+        HRN_STORAGE_PUT_Z(
+            storageTest, "restore_filter.json",
+            "["
+            "  {"
+            "    \"dbOid\": 1,"
+            "    \"tables\": ["
+            "      {"
+            "        \"tablespace\": 1663,"
+            "        \"relfilenode\": 40045"
+            "      }"
+            "    ]"
+            "  },"
+            "  {"
+            "    \"dbOid\": 16416,"
+            "    \"tables\": ["
+            "      {"
+            "        \"tablespace\": 16415,"
+            "        \"relfilenode\": 20000"
+            "      }"
+            "    ]"
+            "  }"
+            "]");
+
+        argList = strLstNew();
+        hrnCfgArgRawZ(argList, cfgOptStanza, "test1");
+        hrnCfgArgRaw(argList, cfgOptRepoPath, repoPath);
+        hrnCfgArgRaw(argList, cfgOptPgPath, pgPath);
+        hrnCfgArgRawZ(argList, cfgOptSpoolPath, TEST_PATH "/spool");
+        hrnCfgArgRawZ(argList, cfgOptRepoCipherType, "aes-256-cbc");
+        hrnCfgEnvRawZ(cfgOptRepoCipherPass, TEST_CIPHER_PASS);
+        hrnCfgArgRawZ(argList, cfgOptFilter, TEST_PATH "/restore_filter.json");
+        HRN_CFG_LOAD(cfgCmdRestore, argList);
+
+        TEST_RESULT_VOID(cmdRestore(), "restore");
+
+        // base/1/40044* are filtered out
+        TEST_STORAGE_LIST(
+            storagePg(), NULL,
+            "PG_VERSION\n"
+            "base/\n"
+            "base/1/\n"
+            "base/1/2\n"
+            "base/1/3\n"
+            "base/1/40045\n"
+            "base/1/40045_fsm\n"
+            "base/1/40045_vm\n"
+            "base/1/44\n"
+            "global/\n"
+            "global/pg_control\n"
+            PG_PATH_PGTBLSPC "/\n"
+            PG_PATH_PGTBLSPC "/16415>\n"
+            "postgresql.auto.conf\n",
+            .level = storageInfoLevelType);
+
+        // 16416/20001* are filtered out
+        TEST_STORAGE_LIST(
+            storageTest, "ts/PG_15_202209061",
+            "16416/\n"
+            "16416/20000\n"
+            "16416/20000_fsm\n"
+            "16416/20000_vm\n"
+            "16416/" PG_FILE_PGVERSION "\n",
+            .level = storageInfoLevelType);
     }
 
     FUNCTION_HARNESS_RETURN_VOID();

--- a/test/src/module/command/restoreTest.c
+++ b/test/src/module/command/restoreTest.c
@@ -3404,6 +3404,8 @@ testRun(void)
         HRN_STORAGE_PUT_EMPTY(storagePgWrite(), PG_PATH_BASE "/1/40045");
         HRN_STORAGE_PUT_EMPTY(storagePgWrite(), PG_PATH_BASE "/1/40045_fsm");
         HRN_STORAGE_PUT_EMPTY(storagePgWrite(), PG_PATH_BASE "/1/40045_vm");
+        HRN_STORAGE_PUT_EMPTY(storagePgWrite(), PG_PATH_BASE "/1/" PG_FILE_PGVERSION);
+        HRN_STORAGE_PUT_EMPTY(storagePgWrite(), PG_PATH_BASE "/1/pg_filenode.map");
         HRN_STORAGE_PUT_EMPTY(storageTest, "ts/GPDB_6_301908232/16416/20000");
         HRN_STORAGE_PUT_EMPTY(storageTest, "ts/GPDB_6_301908232/16416/20000_fsm");
         HRN_STORAGE_PUT_EMPTY(storageTest, "ts/GPDB_6_301908232/16416/20000_vm");
@@ -3492,6 +3494,8 @@ testRun(void)
             "base/1/40045\n"
             "base/1/40045_fsm\n"
             "base/1/40045_vm\n"
+            "base/1/" PG_FILE_PGVERSION "\n"
+            "base/1/pg_filenode.map\n"
             "global/\n"
             "global/pg_control\n"
             PG_PATH_PGTBLSPC "/\n"


### PR DESCRIPTION
Add the --filter option for the restore command

Do not add a file into the processing queues, when the file should be filtered
out according to the JSON file from the --filter option. Check files from the
pg_default tablespace and non-built-in tablespaces. User relations can not be
placed in the pg_global tablespace, so this tablespace files are not checked.
Remove the unused attribute, because isRelationNeeded is used now.