### PR TITLE
ADBDEV-6381: Fix the build with the old gcc

### DIFF
--- a/test/src/common/harnessWal.c
+++ b/test/src/common/harnessWal.c
@@ -57,7 +57,8 @@ hrnGpdbWalInsertXRecord(
     if (bufUsed(walBuffer) == 0)
     {
         // This is first record
-        XLogLongPageHeaderData longHeader = {0};
+        // Workaround gcc bug 53119
+        XLogLongPageHeaderData longHeader = {{0}};
         longHeader.std.xlp_magic = param.magic;
         longHeader.std.xlp_info = XLP_LONG_HEADER;
         longHeader.std.xlp_tli = 1;


### PR DESCRIPTION
Fix the build with the old gcc

In gcc 4.8.5, which is used in CentOS 7, there is a bug 53119 from which the
warning "missing braces around initializer" is issued when the structure
containing the nested structure is initialized to zero. Which leads to a build
error with Werror.

This patch fixes the initialization by a workaround.