### PR TITLE
ADBDEV-6761: Always restore system objects of database

### DIFF
--- a/src/common/partialRestore.c
+++ b/src/common/partialRestore.c
@@ -117,7 +117,8 @@ isRelationNeeded(const Oid dbNode, const Oid spcNode, const Oid relNode)
     if (!cfgOptionTest(cfgOptFilter))
         return true;
 
-    if (pgDbIsSystemId(dbNode) && pgDbIsSystemId(relNode))
+    // Restore all system objects.
+    if (pgDbIsSystemId(relNode))
         return true;
 
     static List *filterList = NULL;
@@ -145,7 +146,5 @@ isRelationNeeded(const Oid dbNode, const Oid spcNode, const Oid relNode)
     if (db == NULL)
         return false;
 
-    return
-        pgDbIsSystemId(relNode) ||
-        lstExists(db->tables, &(Table){.spcNode = spcNode, .relNode = relNode});
+    return lstExists(db->tables, &(Table){.spcNode = spcNode, .relNode = relNode});
 }

--- a/test/src/module/command/restoreTest.c
+++ b/test/src/module/command/restoreTest.c
@@ -3406,6 +3406,9 @@ testRun(void)
         HRN_STORAGE_PUT_EMPTY(storagePgWrite(), PG_PATH_BASE "/1/40045_vm");
         HRN_STORAGE_PUT_EMPTY(storagePgWrite(), PG_PATH_BASE "/1/" PG_FILE_PGVERSION);
         HRN_STORAGE_PUT_EMPTY(storagePgWrite(), PG_PATH_BASE "/1/pg_filenode.map");
+        HRN_STORAGE_PUT_EMPTY(storagePgWrite(), PG_PATH_BASE "/2/11976");
+        HRN_STORAGE_PUT_EMPTY(storagePgWrite(), PG_PATH_BASE "/2/11976_fsm");
+        HRN_STORAGE_PUT_EMPTY(storagePgWrite(), PG_PATH_BASE "/2/11976_vm");
         HRN_STORAGE_PUT_EMPTY(storageTest, "ts/GPDB_6_301908232/16416/20000");
         HRN_STORAGE_PUT_EMPTY(storageTest, "ts/GPDB_6_301908232/16416/20000_fsm");
         HRN_STORAGE_PUT_EMPTY(storageTest, "ts/GPDB_6_301908232/16416/20000_vm");
@@ -3485,6 +3488,7 @@ testRun(void)
         TEST_RESULT_VOID(cmdRestore(), "restore");
 
         // base/1/40044* are filtered out
+        // base/2/11976* are restored
         TEST_STORAGE_LIST(
             storagePg(), NULL,
             "base/\n"
@@ -3494,6 +3498,10 @@ testRun(void)
             "base/1/40045_vm\n"
             "base/1/" PG_FILE_PGVERSION "\n"
             "base/1/pg_filenode.map\n"
+            "base/2/\n"
+            "base/2/11976\n"
+            "base/2/11976_fsm\n"
+            "base/2/11976_vm\n"
             "global/\n"
             "global/pg_control\n"
             PG_PATH_PGTBLSPC "/\n"

--- a/test/src/module/common/walFilterTest.c
+++ b/test/src/module/common/walFilterTest.c
@@ -1782,7 +1782,6 @@ testRun(void)
                 {2000, 20001, 48457},
                 // should pass filter
                 {2000, 20001, 5445},
-                // should be filter out
                 {2000, 20003, 1000}
             };
 
@@ -1813,7 +1812,7 @@ testRun(void)
                 {RM_XLOG_ID, XLOG_NOOP,        sizeof(RelFileNode), &nodes[7]},
                 {RM_XLOG_ID, XLOG_NOOP,        sizeof(RelFileNode), &nodes[8]},
                 {RM_HEAP_ID, XLOG_HEAP_INSERT, sizeof(RelFileNode), &nodes[9]},
-                {RM_XLOG_ID, XLOG_NOOP, sizeof(RelFileNode), &nodes[10]},
+                {RM_HEAP_ID, XLOG_HEAP_INSERT, sizeof(RelFileNode), &nodes[10]},
             };
 
             buildWalP(wal, records, LENGTH_OF(records), 0);


### PR DESCRIPTION
Always restore system objects of database

Previously, when restoring with an empty filter (an empty array), the system
catalog was restored only for these databases: postgres, template1 and
template0. In this case, we cannot get metadata from user databases. Because of
this, it was required to get the OIDs of the user databases first and restore
again with user databases, whose OIDs had been obtained on the previous step. To
do one step to get metadata about tables instead of these two steps, the system
catalog is restored for all restoring databases.