### PR TITLE
ADBDEV-6412: Add GPDB 7 support for integration test

### DIFF
--- a/arenadata/Dockerfile
+++ b/arenadata/Dockerfile
@@ -1,4 +1,4 @@
-ARG GPDB_IMAGE=gpdb6_regress:latest
+ARG GPDB_IMAGE=gpdb6_u22:latest
 FROM $GPDB_IMAGE
 
 COPY . /home/gpadmin/pgbackrest

--- a/arenadata/README.md
+++ b/arenadata/README.md
@@ -12,5 +12,6 @@ To run the tests, execute the script:
 <path_to_pgbackrest>/arenadata/run_docker.sh <image_id> [arch type]
 ```
 [arch type] stands for CPU architecture. Default value is x86-64. This argument is needed only for log files namings.
+[image_id] supports both GPDB 6 (`gpdb6_u22:latest`) and GPDB 7 (`gpdb7_u22:latest`).
 
 After launching the container the test scripts from `scripts` directory are executed. The logs will be stored in `<path_to_pgbackrest>/arenadata/logs` directory.

--- a/arenadata/README.md
+++ b/arenadata/README.md
@@ -9,9 +9,9 @@ It is preferable to have a container build from GPDB repo's [Dockerfile](https:/
 **Launch**
 To run the tests, execute the script:
 ```
-<path_to_pgbackrest>/arenadata/run_docker.sh <image_id> [arch type]
+<path_to_pgbackrest>/arenadata/run_docker.sh <image_name> [arch type]
 ```
 [arch type] stands for CPU architecture. Default value is x86-64. This argument is needed only for log files namings.
-[image_id] supports both GPDB 6 (`gpdb6_u22:latest`) and GPDB 7 (`gpdb7_u22:latest`).
+[image_name] supports both GPDB 6 (`hub.adsw.io/library/gpdb6_u22:latest`) and GPDB 7 (`hub.adsw.io/library/gpdb7_u22:latest`).
 
 After launching the container the test scripts from `scripts` directory are executed. The logs will be stored in `<path_to_pgbackrest>/arenadata/logs` directory.

--- a/arenadata/run_docker.sh
+++ b/arenadata/run_docker.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -exo pipefail
 
-DOCKERIMAGE="${1:-hub.adsw.io/library/gpdb6_regress:latest}"
+DOCKERIMAGE="${1:-hub.adsw.io/library/gpdb6_u22:latest}"
 ARCH="${2:-x86-64}"
 SCRIPT_PATH="$(dirname "$(realpath -s "$0")")"
 PROJECT_ROOT="$(dirname "$SCRIPT_PATH")"

--- a/arenadata/scripts/test_pitr_gpdb.sh
+++ b/arenadata/scripts/test_pitr_gpdb.sh
@@ -122,8 +122,15 @@ do
    check_backup $i
 done
 
+# Determine version
+GP_VERSION_NUM=$(pg_config --gp_version | cut -c 11)
+
 # Creating a distributed restore point..."
-psql -c "create extension gp_pitr;"
+if [ $GP_VERSION_NUM -le 6 ]; then
+    psql -c "create extension gp_pitr;"
+else
+    RESTORE_OPTIONS="--target-action=promote"
+fi
 psql -c "select gp_create_restore_point('test_pitr');"
 psql -c "select gp_switch_wal();"
 
@@ -138,7 +145,7 @@ rm -rf "${MIRROR1:?}/"* "${MIRROR2:?}/"* "${MIRROR3:?}/"* "$DATADIR/standby/"*
 # Restoring cluster
 for i in -1 0 1 2
 do 
-    pgbackrest --stanza=seg$i --type=name --target=test_pitr restore
+    pgbackrest --stanza=seg$i --type=name --target=test_pitr $RESTORE_OPTIONS restore
 done
 
 # Configuring mirrors after primary restore

--- a/arenadata/scripts/test_pitr_gpdb.sh
+++ b/arenadata/scripts/test_pitr_gpdb.sh
@@ -125,13 +125,14 @@ done
 # Determine version
 GP_VERSION_NUM=$(pg_config --gp_version | cut -c 11)
 
-# Creating a distributed restore point..."
+# GPDB 7 doesn't need gp_pitr extension, but needs --target-action=promote
 if [ $GP_VERSION_NUM -le 6 ]; then
     psql -c "create extension gp_pitr;"
     RESTORE_OPTIONS=""
 else
     RESTORE_OPTIONS="--target-action=promote"
 fi
+# Creating a distributed restore point..."
 psql -c "select gp_create_restore_point('test_pitr');"
 psql -c "select gp_switch_wal();"
 

--- a/arenadata/scripts/test_pitr_gpdb.sh
+++ b/arenadata/scripts/test_pitr_gpdb.sh
@@ -128,6 +128,7 @@ GP_VERSION_NUM=$(pg_config --gp_version | cut -c 11)
 # Creating a distributed restore point..."
 if [ $GP_VERSION_NUM -le 6 ]; then
     psql -c "create extension gp_pitr;"
+    RESTORE_OPTIONS=""
 else
     RESTORE_OPTIONS="--target-action=promote"
 fi


### PR DESCRIPTION
Add GPDB 7 support for integration test

Modify `test_pitr_gpdb.sh` (originally named `test_pitr_gpdb6.sh`) to support
running in GPDB 7 container. The only difference is that GPDB 7 doesn't
require `gp_pitr` extension, but requires `--target-action=promote` during
restore. Also updated the default GPDB 6 script to use Ubuntu 22 docker image.