### PR TITLE
ADBM-2033: Add --set filtering for archive verification

### DIFF
--- a/src/command/verify/verify.c
+++ b/src/command/verify/verify.c
@@ -809,7 +809,7 @@ verifyCollectBackupRange(VerifyJobData *const jobData, const String *const backu
                                                 true, jobData->manifestCipherPass);
         }
 
-        // If the main file did not error, then save WAL range of the backup
+        // If the manifest file has no error, then save WAL range of the backup
         if (verifyManifestInfo.errorCode == 0)
         {
             const ManifestData *const manData = manifestData(verifyManifestInfo.manifest);

--- a/src/command/verify/verify.c
+++ b/src/command/verify/verify.c
@@ -801,7 +801,13 @@ verifyCollectBackupRange(VerifyJobData *const jobData, const String *const backu
         const String *const fileName = strNewFmt(STORAGE_REPO_BACKUP "/%s/" BACKUP_MANIFEST_FILE, strZ(backupLabel));
 
         // Get the main manifest file
-        const VerifyInfoFile verifyManifestInfo = verifyInfoFile(fileName, true, jobData->manifestCipherPass);
+        VerifyInfoFile verifyManifestInfo = verifyInfoFile(fileName, true, jobData->manifestCipherPass);
+        if (verifyManifestInfo.errorCode != 0)
+        {
+            // Attempt to read manifest copy instead
+            verifyManifestInfo = verifyInfoFile(strNewFmt("%s%s", strZ(fileName), INFO_COPY_EXT),
+                                                true, jobData->manifestCipherPass);
+        }
 
         // If the main file did not error, then save WAL range of the backup
         if (verifyManifestInfo.errorCode == 0)

--- a/src/command/verify/verify.c
+++ b/src/command/verify/verify.c
@@ -1930,7 +1930,7 @@ verifyProcess(const bool verboseText)
                 jobData.archiveIdList = strLstNew();
 
             // Enable archive filtering if --set option is specified
-            if (backupLabel != NULL)
+            if (!backupLabelInvalid && backupLabel != NULL)
             {
                 verifyCollectBackupRange(&jobData, backupLabel);
                 jobData.enableArchiveFilter = true;

--- a/src/command/verify/verify.c
+++ b/src/command/verify/verify.c
@@ -790,8 +790,8 @@ static void
 verifyCollectBackupRange(VerifyJobData *const jobData, const String *const backupLabel)
 {
     FUNCTION_TEST_BEGIN();
-        FUNCTION_TEST_PARAM_P(VOID, jobData);  // The result set for the archive Id being processed
-        FUNCTION_TEST_PARAM(STRING, backupLabel);                  // Sorted (ascending) list of WAL files in a timeline
+        FUNCTION_TEST_PARAM_P(VOID, jobData);       // Pointer to the job data
+        FUNCTION_TEST_PARAM(STRING, backupLabel);   // Label of a backup to use for WAL filtering
     FUNCTION_TEST_END();
 
     FUNCTION_AUDIT_HELPER();
@@ -816,6 +816,7 @@ verifyCollectBackupRange(VerifyJobData *const jobData, const String *const backu
         }
         else
         {
+            // If couldn't read the manifest, range is NULL and no archives will be checked.
             jobData->archiveStart = NULL;
             jobData->archiveStop = NULL;
         }
@@ -1928,7 +1929,7 @@ verifyProcess(const bool verboseText)
             else
                 jobData.archiveIdList = strLstNew();
 
-            // If --set option is specified, enable archive filtering
+            // Enable archive filtering if --set option is specified
             if (backupLabel != NULL)
             {
                 verifyCollectBackupRange(&jobData, backupLabel);

--- a/src/command/verify/verify.c
+++ b/src/command/verify/verify.c
@@ -130,6 +130,9 @@ typedef struct VerifyJobData
     unsigned int jobErrorTotal;                                     // Total errors that occurred during the job execution
     List *archiveIdResultList;                                      // Archive results
     List *backupResultList;                                         // Backup results
+    bool enableArchiveFilter;                                       // Only check archives in the specified range
+    const String *archiveStart;                                     // Start of the WAL range to be verified
+    const String *archiveStop;                                      // End of the WAL range to be verified
 } VerifyJobData;
 
 /***********************************************************************************************************************************
@@ -781,6 +784,48 @@ verifyCreateArchiveIdRange(
 }
 
 /***********************************************************************************************************************************
+Populate the WAL range to be verified later based on the specified backup
+***********************************************************************************************************************************/
+static void
+verifyCollectBackupRange(VerifyJobData *const jobData, const String *const backupLabel)
+{
+    FUNCTION_TEST_BEGIN();
+        FUNCTION_TEST_PARAM_P(VOID, jobData);  // The result set for the archive Id being processed
+        FUNCTION_TEST_PARAM(STRING, backupLabel);                  // Sorted (ascending) list of WAL files in a timeline
+    FUNCTION_TEST_END();
+
+    FUNCTION_AUDIT_HELPER();
+
+    MEM_CONTEXT_TEMP_BEGIN()
+    {
+        const String *const fileName = strNewFmt(STORAGE_REPO_BACKUP "/%s/" BACKUP_MANIFEST_FILE, strZ(backupLabel));
+
+        // Get the main manifest file
+        const VerifyInfoFile verifyManifestInfo = verifyInfoFile(fileName, true, jobData->manifestCipherPass);
+
+        // If the main file did not error, then save WAL range of the backup
+        if (verifyManifestInfo.errorCode == 0)
+        {
+            const ManifestData *const manData = manifestData(verifyManifestInfo.manifest);
+            MEM_CONTEXT_BEGIN(jobData->memContext)
+            {
+                jobData->archiveStart = strDup(manData->archiveStart);
+                jobData->archiveStop = strDup(manData->archiveStop);
+            }
+            MEM_CONTEXT_END();
+        }
+        else
+        {
+            jobData->archiveStart = NULL;
+            jobData->archiveStop = NULL;
+        }
+    }
+    MEM_CONTEXT_TEMP_END();
+
+    FUNCTION_TEST_RETURN_VOID();
+}
+
+/***********************************************************************************************************************************
 Return verify jobs for the archive
 ***********************************************************************************************************************************/
 static ProtocolParallelJob *
@@ -857,6 +902,34 @@ verifyArchive(VerifyJobData *const jobData)
                                 storageListP(storageRepo(), walFilePath, .expression = WAL_SEGMENT_FILE_REGEXP_STR), sortOrderAsc);
                         }
                         MEM_CONTEXT_END();
+
+                        // Filter WAL files if needed
+                        if (jobData->enableArchiveFilter)
+                        {
+                            // If backup manifest is broken, skip all archives
+                            if (!jobData->archiveStart)
+                                jobData->walFileList = strLstNew();
+
+                            // Skip WAL files that come before range
+                            while (strLstSize(jobData->walFileList) > 0)
+                            {
+                                const String *const item = strLstGet(jobData->walFileList, 0);
+                                if (strCmp(strSubN(item, 0, WAL_SEGMENT_NAME_SIZE), jobData->archiveStart) < 0)
+                                    jobData->walFileList = strLstRemoveIdx(jobData->walFileList, 0);
+                                else
+                                    break;
+                            }
+                            // Skip WAL files that come after range
+                            while (strLstSize(jobData->walFileList) > 0)
+                            {
+                                unsigned int lastIdx = strLstSize(jobData->walFileList) - 1;
+                                const String *const item = strLstGet(jobData->walFileList, lastIdx);
+                                if (strCmp(strSubN(item, 0, WAL_SEGMENT_NAME_SIZE), jobData->archiveStop) > 0)
+                                    jobData->walFileList = strLstRemoveIdx(jobData->walFileList, lastIdx);
+                                else
+                                    break;
+                            }
+                        }
 
                         if (!strLstEmpty(jobData->walFileList))
                         {
@@ -1854,6 +1927,13 @@ verifyProcess(const bool verboseText)
             }
             else
                 jobData.archiveIdList = strLstNew();
+
+            // If --set option is specified, enable archive filtering
+            if (backupLabel != NULL)
+            {
+                verifyCollectBackupRange(&jobData, backupLabel);
+                jobData.enableArchiveFilter = true;
+            }
 
             // Only begin processing if there are some archives or backups in the repo
             if (!strLstEmpty(jobData.archiveIdList) || !strLstEmpty(jobData.backupList))

--- a/test/src/module/command/verifyTest.c
+++ b/test/src/module/command/verifyTest.c
@@ -3496,7 +3496,7 @@ testRun(void)
             zNewFmt(STORAGE_REPO_ARCHIVE "/11-2/0000000500000009/000000050000000900000006-%s", walBufferSha1), walBuffer,
             .comment = "valid WAL");
 
-        // Write manifests for full backup containing unreadable file
+        // Write manifest for full backup using 2 WAL files
         String *manifestContent = strNewFmt(
             "[backup]\n"
             "backup-archive-start=\"000000050000000800000003\"\n"
@@ -3556,7 +3556,7 @@ testRun(void)
         hrnCfgArgRawZ(argList, cfgOptSet, "20181119-153400F");
         HRN_CFG_LOAD(cfgCmdVerify, argList);
 
-        // Write invalid manifests for backup
+        // Write invalid manifest for backup
         manifestContent = strNewZ(
             "[backrest]\n"
             "backrest-format=1234\n");

--- a/test/src/module/command/verifyTest.c
+++ b/test/src/module/command/verifyTest.c
@@ -3577,6 +3577,7 @@ testRun(void)
             "--set with broken backup\n");
         TEST_RESULT_LOG(
             "P00 DETAIL: expected format 5 but found 1234\n"
+            "P00 DETAIL: expected format 5 but found 1234\n"
             "P00 DETAIL: path '11-2/0000000500000007' does not contain any valid WAL to be processed\n"
             "P00 DETAIL: path '11-2/0000000500000008' does not contain any valid WAL to be processed\n"
             "P00 DETAIL: path '11-2/0000000500000009' does not contain any valid WAL to be processed\n"

--- a/test/src/module/command/verifyTest.c
+++ b/test/src/module/command/verifyTest.c
@@ -3395,6 +3395,8 @@ testRun(void)
             "status: error\n"
             "  Backup set 20181119-152900F_20181119-152910D is not valid",
             "--set with invalid backup label, text");
+        TEST_RESULT_LOG(
+            "P00 DETAIL: unable to open missing file '" TEST_PATH "/repo/backup/db/20181119-152900F_20181119-152910D/backup.manifest' for read");
 
         argList = strLstDup(argListBase);
         hrnCfgArgRawZ(argList, cfgOptOutput, "json");
@@ -3412,6 +3414,8 @@ testRun(void)
             "  ]\n"
             "}\n",
             "--set with invalid backup label, json");
+        TEST_RESULT_LOG(
+            "P00 DETAIL: unable to open missing file '" TEST_PATH "/repo/backup/db/20181119-152900F_20181119-152910D/backup.manifest' for read");
 
         // -------------------------------------------------------------------------------------------------------------------------
         TEST_TITLE("--set with backup label of incorrect format");
@@ -3428,6 +3432,8 @@ testRun(void)
             "status: error\n"
             "  'BOGUS' is not a valid backup label format",
             "--set with backup label of incorrect format, text");
+        TEST_RESULT_LOG(
+            "P00 DETAIL: unable to open missing file '" TEST_PATH "/repo/backup/db/BOGUS/backup.manifest' for read");
 
         argList = strLstDup(argListBase);
         hrnCfgArgRawZ(argList, cfgOptOutput, "json");
@@ -3445,6 +3451,141 @@ testRun(void)
             "  ]\n"
             "}\n",
             "--set with backup label of incorrect format, json");
+        TEST_RESULT_LOG(
+            "P00 DETAIL: unable to open missing file '" TEST_PATH "/repo/backup/db/BOGUS/backup.manifest' for read");
+
+        // -------------------------------------------------------------------------------------------------------------------------
+        TEST_TITLE("--set with archive");
+
+        // Load Parameters - single default repo
+        argList = strLstDup(argListBase);
+        hrnCfgArgRawZ(argList, cfgOptOutput, "text");
+        hrnCfgArgRawZ(argList, cfgOptVerbose, "y");
+        hrnCfgArgRawZ(argList, cfgOptSet, "20181119-153300F");
+        HRN_CFG_LOAD(cfgCmdVerify, argList);
+
+        // Create WAL file with just header info and small WAL size
+        Buffer *walBuffer = bufNew((size_t)(1024 * 1024));
+        bufUsedSet(walBuffer, bufSize(walBuffer));
+        memset(bufPtr(walBuffer), 0, bufSize(walBuffer));
+        HRN_PG_WAL_TO_BUFFER(walBuffer, PG_VERSION_11, .size = 1024 * 1024);
+        const char *walBufferSha1 = strZ(strNewEncode(encodingHex, cryptoHashOne(hashTypeSha1, walBuffer)));
+
+        HRN_STORAGE_PUT(
+            storageRepoIdxWrite(0),
+            zNewFmt(STORAGE_REPO_ARCHIVE "/11-2/0000000500000007/000000050000000700000001-%s", walBufferSha1), walBuffer,
+            .comment = "valid WAL");
+        HRN_STORAGE_PUT(
+            storageRepoIdxWrite(0),
+            zNewFmt(STORAGE_REPO_ARCHIVE "/11-2/0000000500000008/000000050000000800000002-%s", walBufferSha1), walBuffer,
+            .comment = "valid WAL");
+        HRN_STORAGE_PUT(
+            storageRepoIdxWrite(0),
+            zNewFmt(STORAGE_REPO_ARCHIVE "/11-2/0000000500000008/000000050000000800000003-%s", walBufferSha1), walBuffer,
+            .comment = "valid WAL");
+        HRN_STORAGE_PUT(
+            storageRepoIdxWrite(0),
+            zNewFmt(STORAGE_REPO_ARCHIVE "/11-2/0000000500000008/000000050000000800000004-%s", walBufferSha1), walBuffer,
+            .comment = "valid WAL");
+        HRN_STORAGE_PUT(
+            storageRepoIdxWrite(0),
+            zNewFmt(STORAGE_REPO_ARCHIVE "/11-2/0000000500000008/000000050000000800000005-%s", walBufferSha1), walBuffer,
+            .comment = "valid WAL");
+        HRN_STORAGE_PUT(
+            storageRepoIdxWrite(0),
+            zNewFmt(STORAGE_REPO_ARCHIVE "/11-2/0000000500000009/000000050000000900000006-%s", walBufferSha1), walBuffer,
+            .comment = "valid WAL");
+
+        // Write manifests for full backup containing unreadable file
+        String *manifestContent = strNewFmt(
+            "[backup]\n"
+            "backup-archive-start=\"000000050000000800000003\"\n"
+            "backup-archive-stop=\"000000050000000800000004\"\n"
+            "backup-label=\"20181119-153300F\"\n"
+            "backup-timestamp-copy-start=0\n"
+            "backup-timestamp-start=0\n"
+            "backup-timestamp-stop=0\n"
+            "backup-type=\"full\"\n"
+            "\n"
+            "[backup:db]\n"
+            TEST_BACKUP_DB2_11
+            TEST_MANIFEST_OPTION_ALL
+            TEST_MANIFEST_TARGET
+            TEST_MANIFEST_DB
+            "\n"
+            "[target:file]\n"
+            "pg_data/testvalid={\"checksum\":\"%s\",\"size\":7,\"timestamp\":1565282114}\n"
+            TEST_MANIFEST_FILE_DEFAULT
+            TEST_MANIFEST_LINK
+            TEST_MANIFEST_LINK_DEFAULT
+            TEST_MANIFEST_PATH
+            TEST_MANIFEST_PATH_DEFAULT,
+            strZ(strNewEncode(encodingHex, fileChecksum)));
+
+        // Write manifests for backup
+        HRN_INFO_PUT(
+            storageRepoWrite(), STORAGE_REPO_BACKUP "/20181119-153300F/" BACKUP_MANIFEST_FILE, strZ(manifestContent),
+            .comment = "valid manifest - full");
+        HRN_INFO_PUT(
+            storageRepoWrite(), STORAGE_REPO_BACKUP "/20181119-153300F/" BACKUP_MANIFEST_FILE INFO_COPY_EXT, strZ(manifestContent),
+            .comment = "valid manifest copy - full");
+
+        // Put the file into the backup
+        HRN_STORAGE_PUT_Z(storageRepoWrite(), STORAGE_REPO_BACKUP "/20181119-153300F/pg_data/testvalid", fileContents);
+
+        // Should only check 2 WAL files
+        TEST_RESULT_STR_Z(
+            verifyProcess(cfgOptionBool(cfgOptVerbose)),
+            "stanza: db\n"
+            "status: ok\n"
+            "  archiveId: 11-2, total WAL checked: 2, total valid WAL: 2\n"
+            "    missing: 0, checksum invalid: 0, size invalid: 0, wal invalid: 0, other: 0\n"
+            "  backup: 20181119-153300F, status: valid, total files checked: 1, total valid files: 1\n"
+            "    missing: 0, checksum invalid: 0, size invalid: 0, wal invalid: 0, other: 0", "--set with a valid backup label\n");
+        TEST_RESULT_LOG(
+            "P00 DETAIL: path '11-2/0000000500000007' does not contain any valid WAL to be processed\n"
+            "P00 DETAIL: path '11-2/0000000500000009' does not contain any valid WAL to be processed\n"
+            "P00 DETAIL: archiveId: 11-2, wal start: 000000050000000800000003, wal stop: 000000050000000800000004");
+
+        // -------------------------------------------------------------------------------------------------------------------------
+        TEST_TITLE("--set with archive and broken backup");
+
+        argList = strLstDup(argListBase);
+        hrnCfgArgRawZ(argList, cfgOptOutput, "text");
+        hrnCfgArgRawZ(argList, cfgOptVerbose, "y");
+        hrnCfgArgRawZ(argList, cfgOptSet, "20181119-153400F");
+        HRN_CFG_LOAD(cfgCmdVerify, argList);
+
+        // Write invalid manifests for backup
+        manifestContent = strNewZ(
+            "[backrest]\n"
+            "backrest-format=1234\n");
+
+        // Deliberately using HRN_STORAGE_PUT_Z instead of HRN_INFO_PUT to write an invalid manifest
+        HRN_STORAGE_PUT_Z(storageRepoWrite(),
+                          STORAGE_REPO_BACKUP "/20181119-153400F/" BACKUP_MANIFEST_FILE,
+                          strZ(manifestContent),
+                          .comment = "invalid manifest - full");
+        HRN_STORAGE_PUT_Z(storageRepoWrite(),
+                          STORAGE_REPO_BACKUP "/20181119-153400F/" BACKUP_MANIFEST_FILE INFO_COPY_EXT,
+                          strZ(manifestContent),
+                          .comment = "invalid manifest copy - full");
+
+        // Should not check any WAL files
+        TEST_RESULT_STR_Z(
+            verifyProcess(cfgOptionBool(cfgOptVerbose)),
+            "stanza: db\n"
+            "status: error\n"
+            "  archiveId: 11-2, total WAL checked: 0, total valid WAL: 0\n"
+            "  backup: 20181119-153400F, status: invalid, total files checked: 0, total valid files: 0",
+            "--set with broken backup\n");
+        TEST_RESULT_LOG(
+            "P00 DETAIL: expected format 5 but found 1234\n"
+            "P00 DETAIL: path '11-2/0000000500000007' does not contain any valid WAL to be processed\n"
+            "P00 DETAIL: path '11-2/0000000500000008' does not contain any valid WAL to be processed\n"
+            "P00 DETAIL: path '11-2/0000000500000009' does not contain any valid WAL to be processed\n"
+            "P00 DETAIL: expected format 5 but found 1234\n"
+            "P00 DETAIL: expected format 5 but found 1234");
     }
 
     FUNCTION_HARNESS_RETURN_VOID();

--- a/test/src/module/command/verifyTest.c
+++ b/test/src/module/command/verifyTest.c
@@ -3395,8 +3395,7 @@ testRun(void)
             "status: error\n"
             "  Backup set 20181119-152900F_20181119-152910D is not valid",
             "--set with invalid backup label, text");
-        TEST_RESULT_LOG(
-            "P00 DETAIL: unable to open missing file '" TEST_PATH "/repo/backup/db/20181119-152900F_20181119-152910D/backup.manifest' for read");
+        TEST_RESULT_LOG("");
 
         argList = strLstDup(argListBase);
         hrnCfgArgRawZ(argList, cfgOptOutput, "json");
@@ -3414,8 +3413,7 @@ testRun(void)
             "  ]\n"
             "}\n",
             "--set with invalid backup label, json");
-        TEST_RESULT_LOG(
-            "P00 DETAIL: unable to open missing file '" TEST_PATH "/repo/backup/db/20181119-152900F_20181119-152910D/backup.manifest' for read");
+        TEST_RESULT_LOG("");
 
         // -------------------------------------------------------------------------------------------------------------------------
         TEST_TITLE("--set with backup label of incorrect format");
@@ -3432,8 +3430,7 @@ testRun(void)
             "status: error\n"
             "  'BOGUS' is not a valid backup label format",
             "--set with backup label of incorrect format, text");
-        TEST_RESULT_LOG(
-            "P00 DETAIL: unable to open missing file '" TEST_PATH "/repo/backup/db/BOGUS/backup.manifest' for read");
+        TEST_RESULT_LOG("");
 
         argList = strLstDup(argListBase);
         hrnCfgArgRawZ(argList, cfgOptOutput, "json");
@@ -3451,8 +3448,7 @@ testRun(void)
             "  ]\n"
             "}\n",
             "--set with backup label of incorrect format, json");
-        TEST_RESULT_LOG(
-            "P00 DETAIL: unable to open missing file '" TEST_PATH "/repo/backup/db/BOGUS/backup.manifest' for read");
+        TEST_RESULT_LOG("");
 
         // -------------------------------------------------------------------------------------------------------------------------
         TEST_TITLE("--set with archive");


### PR DESCRIPTION
Add --set filtering for archive verification

Previously --set only applied filtering to backup verification. This patch
also implements it for WAL file verification, only checking the files required
by the backup. If backup manifest is unreadable, no WAL files are checked.