### PR TITLE
ADBM-1975: Add progress only mode for info command

### DIFF
--- a/src/build/config/config.yaml
+++ b/src/build/config/config.yaml
@@ -353,6 +353,14 @@ option:
     command-role:
       main: {}
 
+  progress-only:
+    type: boolean
+    default: false
+    command:
+      info: {}
+    command-role:
+      main: {}
+
   reference:
     type: string
     required: false

--- a/src/build/help/help.xml
+++ b/src/build/help/help.xml
@@ -2593,6 +2593,17 @@
                         <example>json</example>
                     </option>
 
+                    <option id="progress-only" name="Progress Only">
+                        <summary>Get only progress information.</summary>
+
+                        <text>
+                            <p>Specifying this options as true displays only the progress details of the backup/expire or restore process. As it skips repository access, it speeds up retrieving such information.</p>
+                            <p>Note that the info command with this option does not perform any additional checks, except for the availability of the stanza. To obtain comprehensive information, use the full version of the info command.</p>
+                        </text>
+
+                        <example>y</example>
+                    </option>
+
                     <option id="set" name="Set">
                         <summary>Backup set to detail.</summary>
 

--- a/src/build/help/help.xml
+++ b/src/build/help/help.xml
@@ -2597,7 +2597,7 @@
                         <summary>Get only progress information.</summary>
 
                         <text>
-                            <p>Specifying this options as true displays only the progress details of the backup/expire or restore process. As it skips repository access, it speeds up retrieving such information.</p>
+                            <p>Specifying this option as true displays only the progress details of the backup/expire or restore process. As it skips repository access, it speeds up retrieving such information.</p>
                             <p>Note that the info command with this option does not perform any additional checks, except for the availability of the stanza. To obtain comprehensive information, use the full version of the info command.</p>
                         </text>
 

--- a/src/command/info/info.c
+++ b/src/command/info/info.c
@@ -714,6 +714,7 @@ stanzaInfoList(
         FUNCTION_TEST_PARAM(STRING, backupLabel);
         FUNCTION_TEST_PARAM(UINT, repoIdxMin);
         FUNCTION_TEST_PARAM(UINT, repoIdxMax);
+        FUNCTION_TEST_PARAM(BOOL, progressOnly);
     FUNCTION_TEST_END();
 
     FUNCTION_AUDIT_HELPER();

--- a/src/command/info/info.c
+++ b/src/command/info/info.c
@@ -1361,7 +1361,7 @@ infoUpdateStanza(
                 }
                 TRY_END();
 
-                // If backup.info was found, then get the archive.info, which must exist if the backup.info exists, else the failed
+                // If backup.info was found, then get the archive.info file, which must exist if the backup.info exists, else the failed
                 // load will throw an error which will be trapped and recorded
                 if (stanzaRepo->repoList[repoIdx].backupInfo != NULL)
                 {
@@ -1738,7 +1738,7 @@ infoRender(void)
                             strCatFmt(resultStr, "%s\n", INFO_STANZA_STATUS_OK);
                     }
 
-                    //  if progressOnly mode is disabled and the stanza is found on at least one repo add cipher type
+                    // If progressOnly mode is disabled and the stanza is found on at least one repo add cipher type
                     if (!progressOnly && statusCode != INFO_STANZA_STATUS_CODE_MISSING_STANZA_PATH)
                     {
                         strCatFmt(resultStr, "    cipher: %s\n", strZ(varStr(kvGet(stanzaInfo, KEY_CIPHER_VAR))));

--- a/src/command/info/info.c
+++ b/src/command/info/info.c
@@ -1361,7 +1361,7 @@ infoUpdateStanza(
                 }
                 TRY_END();
 
-                // If backup.info was found, then get the archive.info file, which must exist if the backup.info exists, else the failed
+                // If backup.info was found, then get the archive.info, which must exist if the backup.info exists, else the failed
                 // load will throw an error which will be trapped and recorded
                 if (stanzaRepo->repoList[repoIdx].backupInfo != NULL)
                 {

--- a/src/command/info/info.c
+++ b/src/command/info/info.c
@@ -706,7 +706,8 @@ Set the stanza data for each stanza found in the repo
 ***********************************************************************************************************************************/
 static VariantList *
 stanzaInfoList(
-    List *const stanzaRepoList, const String *const backupLabel, const unsigned int repoIdxMin, const unsigned int repoIdxMax)
+    List *const stanzaRepoList, const String *const backupLabel, const unsigned int repoIdxMin,
+    const unsigned int repoIdxMax, const bool progressOnly)
 {
     FUNCTION_TEST_BEGIN();
         FUNCTION_TEST_PARAM(LIST, stanzaRepoList);
@@ -746,6 +747,17 @@ stanzaInfoList(
         for (unsigned int repoIdx = repoIdxMin; repoIdx <= repoIdxMax; repoIdx++)
         {
             InfoRepoData *const repoData = &stanzaData->repoList[repoIdx];
+
+            // If progressOnly mode is enabled, skip collecting additional data and set the status code
+            if (progressOnly)
+            {
+                if (repoIdx == repoIdxMin)
+                    stanzaStatusCode = repoData->stanzaStatus;
+                else
+                    stanzaStatusCode =
+                        stanzaStatusCode != repoData->stanzaStatus ? INFO_STANZA_STATUS_CODE_MIXED : repoData->stanzaStatus;
+                continue;
+            }
 
             Variant *const repoInfo = varNewKv(kvNew());
             kvPut(varKv(repoInfo), REPO_KEY_KEY_VAR, VARUINT(repoData->key));
@@ -833,18 +845,22 @@ stanzaInfoList(
             kvPut(varKv(stanzaInfo), STANZA_KEY_REPO_VAR, varNewVarLst(repoSection));
         }
 
-        // Get a sorted list of the data for all existing backups for this stanza over all repos
-        backupList(backupSection, stanzaData, backupLabel, repoIdxMin, repoIdxMax);
-        kvPut(varKv(stanzaInfo), STANZA_KEY_BACKUP_VAR, varNewVarLst(backupSection));
+        // If progressOnly mode is disabled сollect backup and cipher data.
+        if (!progressOnly)
+        {
+            // Get a sorted list of the data for all existing backups for this stanza over all repos
+            backupList(backupSection, stanzaData, backupLabel, repoIdxMin, repoIdxMax);
+            kvPut(varKv(stanzaInfo), STANZA_KEY_BACKUP_VAR, varNewVarLst(backupSection));
 
-        // Set the overall stanza status
+            // Set the overall cipher type
+            if (stanzaCipherType != INFO_STANZA_STATUS_CODE_MIXED)
+                kvPut(varKv(stanzaInfo), KEY_CIPHER_VAR, VARSTR(strIdToStr(stanzaCipherType)));
+            else
+                kvPut(varKv(stanzaInfo), KEY_CIPHER_VAR, VARSTRDEF(INFO_STANZA_MIXED));
+        }
+
+        // Set the overall stanza status and gather progress information
         stanzaStatus(stanzaStatusCode, stanzaData, stanzaInfo);
-
-        // Set the overall cipher type
-        if (stanzaCipherType != INFO_STANZA_STATUS_CODE_MIXED)
-            kvPut(varKv(stanzaInfo), KEY_CIPHER_VAR, VARSTR(strIdToStr(stanzaCipherType)));
-        else
-            kvPut(varKv(stanzaInfo), KEY_CIPHER_VAR, VARSTRDEF(INFO_STANZA_MIXED));
 
         varLstAdd(result, stanzaInfo);
     }
@@ -1294,7 +1310,7 @@ Get the backup and archive info files on the specified repo for the stanza
 static void
 infoUpdateStanza(
     const Storage *const storage, InfoStanzaRepo *const stanzaRepo, const unsigned int repoIdx, const bool stanzaExists,
-    const String *const backupLabel)
+    const String *const backupLabel, const bool progressOnly)
 {
     FUNCTION_TEST_BEGIN();
         FUNCTION_TEST_PARAM(STORAGE, storage);
@@ -1302,6 +1318,7 @@ infoUpdateStanza(
         FUNCTION_TEST_PARAM(UINT, repoIdx);
         FUNCTION_TEST_PARAM(BOOL, stanzaExists);
         FUNCTION_TEST_PARAM(STRING, backupLabel);
+        FUNCTION_TEST_PARAM(BOOL, progressOnly);
     FUNCTION_TEST_END();
 
     FUNCTION_AUDIT_HELPER();
@@ -1316,47 +1333,54 @@ infoUpdateStanza(
     {
         TRY_BEGIN()
         {
-            // Catch certain errors
-            TRY_BEGIN()
+            // If progressOnly mode is disabled read info and manifest files.
+            if (!progressOnly)
             {
-                // Attempt to load the backup info file
-                stanzaRepo->repoList[repoIdx].backupInfo = infoBackupLoadFile(
-                    storage, strNewFmt(STORAGE_PATH_BACKUP "/%s/%s", strZ(stanzaRepo->name), INFO_BACKUP_FILE),
-                    stanzaRepo->repoList[repoIdx].cipher, stanzaRepo->repoList[repoIdx].cipherPass);
-            }
-            CATCH(FileMissingError)
-            {
-                // If there is no backup.info then set the status to indicate missing
-                stanzaStatus = INFO_STANZA_STATUS_CODE_MISSING_STANZA_DATA;
-            }
-            CATCH(CryptoError)
-            {
-                // If a reason for the error is due to a an encryption error, add a hint
-                THROW_FMT(
-                    CryptoError,
-                    "%s\n"
-                    "HINT: use option --stanza if encryption settings are different for the stanza than the global settings.",
-                    errorMessage());
-            }
-            TRY_END();
-
-            // If backup.info was found, then get the archive.info file, which must exist if the backup.info exists, else the failed
-            // load will throw an error which will be trapped and recorded
-            if (stanzaRepo->repoList[repoIdx].backupInfo != NULL)
-            {
-                stanzaRepo->repoList[repoIdx].archiveInfo = infoArchiveLoadFile(
-                    storage, strNewFmt(STORAGE_PATH_ARCHIVE "/%s/%s", strZ(stanzaRepo->name), INFO_ARCHIVE_FILE),
-                    stanzaRepo->repoList[repoIdx].cipher, stanzaRepo->repoList[repoIdx].cipherPass);
-
-                // If a specific backup exists on this repo then attempt to load the manifest
-                if (backupLabel != NULL)
+                // Catch certain errors
+                TRY_BEGIN()
                 {
-                    stanzaRepo->repoList[repoIdx].manifest = manifestLoadFile(
-                        storage, strNewFmt(STORAGE_REPO_BACKUP "/%s/" BACKUP_MANIFEST_FILE, strZ(backupLabel)),
-                        stanzaRepo->repoList[repoIdx].cipher,
-                        infoPgCipherPass(infoBackupPg(stanzaRepo->repoList[repoIdx].backupInfo)));
+                    // Attempt to load the backup info file
+                    stanzaRepo->repoList[repoIdx].backupInfo = infoBackupLoadFile(
+                        storage, strNewFmt(STORAGE_PATH_BACKUP "/%s/%s", strZ(stanzaRepo->name), INFO_BACKUP_FILE),
+                        stanzaRepo->repoList[repoIdx].cipher, stanzaRepo->repoList[repoIdx].cipherPass);
                 }
+                CATCH(FileMissingError)
+                {
+                    // If there is no backup.info then set the status to indicate missing
+                    stanzaStatus = INFO_STANZA_STATUS_CODE_MISSING_STANZA_DATA;
+                }
+                CATCH(CryptoError)
+                {
+                    // If a reason for the error is due to a an encryption error, add a hint
+                    THROW_FMT(
+                        CryptoError,
+                        "%s\n"
+                        "HINT: use option --stanza if encryption settings are different for the stanza than the global settings.",
+                        errorMessage());
+                }
+                TRY_END();
 
+                // If backup.info was found, then get the archive.info, which must exist if the backup.info exists, else the failed
+                // load will throw an error which will be trapped and recorded
+                if (stanzaRepo->repoList[repoIdx].backupInfo != NULL)
+                {
+                    stanzaRepo->repoList[repoIdx].archiveInfo = infoArchiveLoadFile(
+                        storage, strNewFmt(STORAGE_PATH_ARCHIVE "/%s/%s", strZ(stanzaRepo->name), INFO_ARCHIVE_FILE),
+                        stanzaRepo->repoList[repoIdx].cipher, stanzaRepo->repoList[repoIdx].cipherPass);
+
+                    // If a specific backup exists on this repo then attempt to load the manifest
+                    if (backupLabel != NULL)
+                    {
+                        stanzaRepo->repoList[repoIdx].manifest = manifestLoadFile(
+                            storage, strNewFmt(STORAGE_REPO_BACKUP "/%s/" BACKUP_MANIFEST_FILE, strZ(backupLabel)),
+                            stanzaRepo->repoList[repoIdx].cipher,
+                            infoPgCipherPass(infoBackupPg(stanzaRepo->repoList[repoIdx].backupInfo)));
+                    }
+                }
+            }
+            // Read lock files if progressOnly mode is enabled or backup information is available
+            if (progressOnly || stanzaRepo->repoList[repoIdx].backupInfo != NULL)
+            {
                 infoUpdateStanzaLock(&stanzaRepo->backupLock, stanzaRepo->name, lockTypeBackup);
                 infoUpdateStanzaLock(&stanzaRepo->restoreLock, stanzaRepo->name, lockTypeRestore);
             }
@@ -1398,6 +1422,9 @@ infoRender(void)
 
     MEM_CONTEXT_TEMP_BEGIN()
     {
+        // Is only progress output requested?
+        const bool progressOnly = cfgOptionBool(cfgOptProgressOnly);
+
         // Get stanza if specified
         const String *const stanza = cfgOptionStrNull(cfgOptStanza);
 
@@ -1486,7 +1513,7 @@ infoRender(void)
                     // If the stanza was already added to the array, then update this repo for the stanza, else the stanza has not
                     // yet been added to the list, so add it
                     if (stanzaRepo != NULL)
-                        infoUpdateStanza(storageRepo, stanzaRepo, repoIdx, stanzaExists, backupExistsOnRepo);
+                        infoUpdateStanza(storageRepo, stanzaRepo, repoIdx, stanzaExists, backupExistsOnRepo, progressOnly);
                     else
                     {
                         InfoStanzaRepo stanzaRepo =
@@ -1510,7 +1537,7 @@ infoRender(void)
                         }
 
                         // Update the info for this repo
-                        infoUpdateStanza(storageRepo, &stanzaRepo, repoIdx, stanzaExists, backupExistsOnRepo);
+                        infoUpdateStanza(storageRepo, &stanzaRepo, repoIdx, stanzaExists, backupExistsOnRepo, progressOnly);
                         lstAdd(stanzaRepoList, &stanzaRepo);
                     }
                 }
@@ -1583,7 +1610,7 @@ infoRender(void)
 
         // If the backup storage exists, then search for and process any stanzas
         if (!lstEmpty(stanzaRepoList))
-            infoList = stanzaInfoList(stanzaRepoList, backupLabel, repoIdxMin, repoIdxMax);
+            infoList = stanzaInfoList(stanzaRepoList, backupLabel, repoIdxMin, repoIdxMax, progressOnly);
 
         // Format text output
         if (cfgOptionStrId(cfgOptOutput) == CFGOPTVAL_OUTPUT_TEXT)
@@ -1627,9 +1654,11 @@ infoRender(void)
 
                     if (statusCode != INFO_STANZA_STATUS_CODE_OK)
                     {
-                        // Update the overall stanza status and change displayed status if backup lock is found
-                        if (statusCode == INFO_STANZA_STATUS_CODE_MIXED || statusCode == INFO_STANZA_STATUS_CODE_PG_MISMATCH ||
-                            statusCode == INFO_STANZA_STATUS_CODE_OTHER)
+                        // Update the overall stanza status and change displayed status if backup lock is found.
+                        // If progressOnly mode is enabled, omit detailed error messages since they are not recorded.
+                        if (!progressOnly && (statusCode == INFO_STANZA_STATUS_CODE_MIXED ||
+                                              statusCode == INFO_STANZA_STATUS_CODE_PG_MISMATCH ||
+                                              statusCode == INFO_STANZA_STATUS_CODE_OTHER))
                         {
                             // Stanza status
                             strCatFmt(
@@ -1708,8 +1737,8 @@ infoRender(void)
                             strCatFmt(resultStr, "%s\n", INFO_STANZA_STATUS_OK);
                     }
 
-                    // Add cipher type if the stanza is found on at least one repo
-                    if (statusCode != INFO_STANZA_STATUS_CODE_MISSING_STANZA_PATH)
+                    //  if progressOnly mode is disabled and the stanza is found on at least one repo add cipher type
+                    if (!progressOnly && statusCode != INFO_STANZA_STATUS_CODE_MISSING_STANZA_PATH)
                     {
                         strCatFmt(resultStr, "    cipher: %s\n", strZ(varStr(kvGet(stanzaInfo, KEY_CIPHER_VAR))));
 
@@ -1729,8 +1758,8 @@ infoRender(void)
                         }
                     }
 
-                    // Get the current database for this stanza
-                    if (!varLstEmpty(kvGetList(stanzaInfo, STANZA_KEY_DB_VAR)))
+                    // If progressOnly mode is disabled get the current database for this stanza
+                    if (!progressOnly && !varLstEmpty(kvGetList(stanzaInfo, STANZA_KEY_DB_VAR)))
                     {
                         const InfoStanzaRepo *const stanzaRepo = lstFind(stanzaRepoList, &stanzaName);
 

--- a/src/config/config.auto.h
+++ b/src/config/config.auto.h
@@ -102,6 +102,7 @@ Option constants
 #define CFGOPT_PG_VERSION_FORCE                                     "pg-version-force"
 #define CFGOPT_PROCESS                                              "process"
 #define CFGOPT_PROCESS_MAX                                          "process-max"
+#define CFGOPT_PROGRESS_ONLY                                        "progress-only"
 #define CFGOPT_PROTOCOL_TIMEOUT                                     "protocol-timeout"
 #define CFGOPT_RAW                                                  "raw"
 #define CFGOPT_RECOVERY_OPTION                                      "recovery-option"
@@ -137,7 +138,7 @@ Option constants
 #define CFGOPT_TYPE                                                 "type"
 #define CFGOPT_VERBOSE                                              "verbose"
 
-#define CFG_OPTION_TOTAL                                            181
+#define CFG_OPTION_TOTAL                                            182
 
 /***********************************************************************************************************************************
 Option value constants
@@ -466,6 +467,7 @@ typedef enum
     cfgOptPgVersionForce,
     cfgOptProcess,
     cfgOptProcessMax,
+    cfgOptProgressOnly,
     cfgOptProtocolTimeout,
     cfgOptRaw,
     cfgOptRecoveryOption,

--- a/src/config/parse.auto.c.inc
+++ b/src/config/parse.auto.c.inc
@@ -4425,6 +4425,30 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         ),                                                                                                        // opt/process-max
     ),                                                                                                            // opt/process-max
     // -----------------------------------------------------------------------------------------------------------------------------
+    PARSE_RULE_OPTION                                                                                           // opt/progress-only
+    (                                                                                                           // opt/progress-only
+        PARSE_RULE_OPTION_NAME("progress-only"),                                                                // opt/progress-only
+        PARSE_RULE_OPTION_TYPE(cfgOptTypeBoolean),                                                              // opt/progress-only
+        PARSE_RULE_OPTION_REQUIRED(true),                                                                       // opt/progress-only
+        PARSE_RULE_OPTION_SECTION(cfgSectionCommandLine),                                                       // opt/progress-only
+                                                                                                                // opt/progress-only
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST                                                          // opt/progress-only
+        (                                                                                                       // opt/progress-only
+            PARSE_RULE_OPTION_COMMAND(cfgCmdInfo)                                                               // opt/progress-only
+        ),                                                                                                      // opt/progress-only
+                                                                                                                // opt/progress-only
+        PARSE_RULE_OPTIONAL                                                                                     // opt/progress-only
+        (                                                                                                       // opt/progress-only
+            PARSE_RULE_OPTIONAL_GROUP                                                                           // opt/progress-only
+            (                                                                                                   // opt/progress-only
+                PARSE_RULE_OPTIONAL_DEFAULT                                                                     // opt/progress-only
+                (                                                                                               // opt/progress-only
+                    PARSE_RULE_VAL_BOOL_FALSE,                                                                  // opt/progress-only
+                ),                                                                                              // opt/progress-only
+            ),                                                                                                  // opt/progress-only
+        ),                                                                                                      // opt/progress-only
+    ),                                                                                                          // opt/progress-only
+    // -----------------------------------------------------------------------------------------------------------------------------
     PARSE_RULE_OPTION                                                                                        // opt/protocol-timeout
     (                                                                                                        // opt/protocol-timeout
         PARSE_RULE_OPTION_NAME("protocol-timeout"),                                                          // opt/protocol-timeout
@@ -11064,6 +11088,7 @@ static const uint8_t optionResolveOrder[] =
     cfgOptPgVersionForce,                                                                                       // opt-resolve-order
     cfgOptProcess,                                                                                              // opt-resolve-order
     cfgOptProcessMax,                                                                                           // opt-resolve-order
+    cfgOptProgressOnly,                                                                                         // opt-resolve-order
     cfgOptProtocolTimeout,                                                                                      // opt-resolve-order
     cfgOptRaw,                                                                                                  // opt-resolve-order
     cfgOptRecurse,                                                                                              // opt-resolve-order

--- a/test/src/module/command/infoTest.c
+++ b/test/src/module/command/infoTest.c
@@ -34,13 +34,25 @@ testRun(void)
         hrnCfgArgRawZ(argList, cfgOptOutput, "json");
         HRN_CFG_LOAD(cfgCmdInfo, argList);
 
+        StringList *argListProgressOnly = strLstDup(argList);
+        hrnCfgArgRawZ(argListProgressOnly, cfgOptProgressOnly, "y");
+
+        StringList *argListTextProgressOnly = strLstDup(argListText);
+        hrnCfgArgRawZ(argListTextProgressOnly, cfgOptProgressOnly, "y");
+
         // -------------------------------------------------------------------------------------------------------------------------
         TEST_TITLE("no stanzas have been created");
 
         TEST_RESULT_STR_Z(infoRender(), "[]", "json - repo but no stanzas");
 
+        HRN_CFG_LOAD(cfgCmdInfo, argListProgressOnly);
+        TEST_RESULT_STR_Z(infoRender(), "[]", "json (progress only) - repo but no stanzas");
+
         HRN_CFG_LOAD(cfgCmdInfo, argListText);
         TEST_RESULT_STR_Z(infoRender(), "No stanzas exist in the repository.\n", "text - no stanzas");
+
+        HRN_CFG_LOAD(cfgCmdInfo, argListTextProgressOnly);
+        TEST_RESULT_STR_Z(infoRender(), "No stanzas exist in the repository.\n", "text (progress only) - no stanzas");
 
         // -------------------------------------------------------------------------------------------------------------------------
         TEST_TITLE("repo is still empty but stanza option is specified");
@@ -81,6 +93,28 @@ testRun(void)
             // {uncrustify_on}
             "json - empty repo, stanza option specified");
 
+        StringList *argListProgressOnlyStanzaOpt = strLstDup(argListProgressOnly);
+        hrnCfgArgRawZ(argListProgressOnlyStanzaOpt, cfgOptStanza, "stanza1");
+        HRN_CFG_LOAD(cfgCmdInfo, argListProgressOnlyStanzaOpt);
+        TEST_RESULT_STR_Z(
+            infoRender(),
+            // {uncrustify_off - indentation}
+            "["
+                "{"
+                    "\"name\":\"stanza1\","
+                    "\"status\":{"
+                        "\"code\":1,"
+                        "\"lock\":{"
+                            "\"backup\":{\"held\":false},"
+                            "\"restore\":{\"held\":false}"
+                        "},"
+                        "\"message\":\"missing stanza path\""
+                    "}"
+                "}"
+            "]",
+            // {uncrustify_on}
+            "json (progress only) - empty repo, stanza option specified");
+
         StringList *argListTextStanzaOpt = strLstDup(argListText);
         hrnCfgArgRawZ(argListTextStanzaOpt, cfgOptStanza, "stanza1");
         HRN_CFG_LOAD(cfgCmdInfo, argListTextStanzaOpt);
@@ -90,12 +124,22 @@ testRun(void)
             "    status: error (missing stanza path)\n",
             "text - empty repo, stanza option specified");
 
+        StringList *argListTextProgressOnlyStanzaOpt = strLstDup(argListTextProgressOnly);
+        hrnCfgArgRawZ(argListTextProgressOnlyStanzaOpt, cfgOptStanza, "stanza1");
+        HRN_CFG_LOAD(cfgCmdInfo, argListTextProgressOnlyStanzaOpt);
+        TEST_RESULT_STR_Z(
+            infoRender(),
+            "stanza: stanza1\n"
+            "    status: error (missing stanza path)\n",
+            "text (progress only) - empty repo, stanza option specified");
+
         // -------------------------------------------------------------------------------------------------------------------------
         TEST_TITLE("stanza path exists but is empty");
 
         HRN_STORAGE_PATH_CREATE(storageRepoWrite(), STORAGE_REPO_ARCHIVE, .comment = "create repo stanza archive path");
         HRN_STORAGE_PATH_CREATE(storageRepoWrite(), STORAGE_REPO_BACKUP, .comment = "create repo stanza backup path");
 
+        HRN_CFG_LOAD(cfgCmdInfo, argListTextStanzaOpt);
         TEST_RESULT_STR_Z(
             infoRender(),
             "stanza: stanza1\n"
@@ -103,7 +147,16 @@ testRun(void)
             "    cipher: none\n",
             "text - missing stanza data");
 
-        HRN_CFG_LOAD(cfgCmdInfo, argList);
+        // In progress-only mode, the info command skips additional checks,
+        // verifying only the availability of the stanza. The status will be `ok`.
+        HRN_CFG_LOAD(cfgCmdInfo, argListTextProgressOnlyStanzaOpt);
+        TEST_RESULT_STR_Z(
+            infoRender(),
+            "stanza: stanza1\n"
+            "    status: ok\n",
+            "text (progress only) - missing stanza data");
+
+        HRN_CFG_LOAD(cfgCmdInfo, argListStanzaOpt);
         TEST_RESULT_STR_Z(
             infoRender(),
             // {uncrustify_off - indentation}
@@ -137,6 +190,28 @@ testRun(void)
             // {uncrustify_on}
             "json - missing stanza data");
 
+        // In progress-only mode, the info command skips additional checks,
+        // verifying only the availability of the stanza. The status will be `ok`.
+        HRN_CFG_LOAD(cfgCmdInfo, argListProgressOnlyStanzaOpt);
+        TEST_RESULT_STR_Z(
+            infoRender(),
+            // {uncrustify_off - indentation}
+            "["
+                "{"
+                    "\"name\":\"stanza1\","
+                    "\"status\":{"
+                        "\"code\":0,"
+                        "\"lock\":{"
+                            "\"backup\":{\"held\":false},"
+                            "\"restore\":{\"held\":false}"
+                        "},"
+                        "\"message\":\"ok\""
+                    "}"
+                "}"
+            "]",
+            // {uncrustify_on}
+            "json (progress only) - missing stanza data");
+
         // -------------------------------------------------------------------------------------------------------------------------
         TEST_TITLE("backup.info file exists, but archive.info does not");
 
@@ -156,6 +231,7 @@ testRun(void)
             "2={\"db-catalog-version\":201608131,\"db-control-version\":960,\"db-system-id\":6569239123849665679"
             ",\"db-version\":\"9.6\"}\n");
 
+        HRN_CFG_LOAD(cfgCmdInfo, argListStanzaOpt);
         TEST_RESULT_STR_Z(
             infoRender(),
             // {uncrustify_off - indentation}
@@ -472,6 +548,16 @@ testRun(void)
             "    status: error (missing stanza path)\n",
             "text - multi-repo, requested stanza missing on selected repo");
 
+        StringList *argList2ProgressOnly = strLstDup(argList2);
+        hrnCfgArgRawZ(argList2ProgressOnly, cfgOptProgressOnly, "y");
+        HRN_CFG_LOAD(cfgCmdInfo, argList2ProgressOnly);
+
+        TEST_RESULT_STR_Z(
+            infoRender(),
+            "stanza: stanza1\n"
+            "    status: error (missing stanza path)\n",
+            "text (progress only) - multi-repo, requested stanza missing on selected repo");
+
         // -------------------------------------------------------------------------------------------------------------------------
         TEST_TITLE("multi-repo - WAL segment on repo1");
 
@@ -495,6 +581,17 @@ testRun(void)
             "    db (current)\n"
             "        wal archive min/max (9.6): 000000030000000000000001/000000030000000000000001\n",
             "text - multi-repo, single stanza, one wal segment");
+
+        argList2ProgressOnly = strLstDup(argList2);
+        hrnCfgArgRawZ(argList2ProgressOnly, cfgOptProgressOnly, "y");
+        HRN_CFG_LOAD(cfgCmdInfo, argList2ProgressOnly);
+        // In progress-only mode, the info command skips additional checks,
+        // verifying only the availability of the stanza. The status will be `ok`.
+        TEST_RESULT_STR_Z(
+            infoRender(),
+            "stanza: stanza1\n"
+            "    status: ok\n",
+            "text (progress only) - multi-repo, single stanza, one wal segment");
 
         // -------------------------------------------------------------------------------------------------------------------------
         TEST_TITLE("coverage for stanzaStatus branches && percent complete null");
@@ -721,6 +818,26 @@ testRun(void)
                     // {uncrustify_on}
                     "json - single stanza, valid backup, no priors, no archives in latest DB, backup/expire lock detected");
 
+                HRN_CFG_LOAD(cfgCmdInfo, argListProgressOnly);
+                TEST_RESULT_STR_Z(
+                    infoRender(),
+                    // {uncrustify_off - indentation}
+                    "["
+                        "{"
+                            "\"name\":\"stanza1\","
+                            "\"status\":{"
+                                "\"code\":0,"
+                                "\"lock\":{"
+                                    "\"backup\":{\"held\":true},"
+                                    "\"restore\":{\"held\":false}"
+                                "},"
+                                "\"message\":\"ok\""
+                            "}"
+                        "}"
+                    "]",
+                    // {uncrustify_on}
+                    "json (progress only) - single stanza, valid backup, no priors, no archives in latest DB, backup/expire lock detected");
+
                 HRN_CFG_LOAD(cfgCmdInfo, argListText);
                 TEST_RESULT_STR_Z(
                     infoRender(),
@@ -746,6 +863,13 @@ testRun(void)
                     "            database size: 25.7MB, database backup size: 25.7MB\n"
                     "            repo1: backup set size: 3MB, backup size: 3KB\n",
                     "text - single stanza, valid backup, no priors, no archives in latest DB, backup/expire lock detected");
+
+                HRN_CFG_LOAD(cfgCmdInfo, argListTextProgressOnly);
+                TEST_RESULT_STR_Z(
+                    infoRender(),
+                    "stanza: stanza1\n"
+                    "    status: ok (backup/expire running)\n",
+                    "text (progress only) - single stanza, valid backup, no priors, no archives in latest DB, backup/expire lock detected");
 
                 // Notify child to release lock
                 HRN_FORK_PARENT_NOTIFY_PUT(0);
@@ -927,6 +1051,26 @@ testRun(void)
                     // {uncrustify_on}
                     "json - single stanza, valid backup, no priors, no archives in latest DB, restore lock detected");
 
+                HRN_CFG_LOAD(cfgCmdInfo, argListProgressOnly);
+                TEST_RESULT_STR_Z(
+                    infoRender(),
+                    // {uncrustify_off - indentation}
+                    "["
+                        "{"
+                            "\"name\":\"stanza1\","
+                            "\"status\":{"
+                                "\"code\":0,"
+                                "\"lock\":{"
+                                    "\"backup\":{\"held\":false},"
+                                    "\"restore\":{\"held\":true,\"size\":3159000,\"size-cplt\":1435765}"
+                                "},"
+                                "\"message\":\"ok\""
+                            "}"
+                        "}"
+                    "]",
+                    // {uncrustify_on}
+                    "json (progress only) - single stanza, valid backup, no priors, no archives in latest DB, restore lock detected");
+
                 HRN_CFG_LOAD(cfgCmdInfo, argListText);
                 TEST_RESULT_STR_Z(
                     infoRender(),
@@ -952,6 +1096,13 @@ testRun(void)
                     "            database size: 25.7MB, database backup size: 25.7MB\n"
                     "            repo1: backup set size: 3MB, backup size: 3KB\n",
                     "text - single stanza, valid backup, no priors, no archives in latest DB, restore lock detected");
+
+                HRN_CFG_LOAD(cfgCmdInfo, argListTextProgressOnly);
+                TEST_RESULT_STR_Z(
+                    infoRender(),
+                    "stanza: stanza1\n"
+                    "    status: ok (restore running - 45.45% complete)\n",
+                    "text (progress only) - single stanza, valid backup, no priors, no archives in latest DB, restore lock detected");
 
                 // Notify child to release lock
                 HRN_FORK_PARENT_NOTIFY_PUT(0);
@@ -1397,6 +1548,12 @@ testRun(void)
 
         StringList *argListMultiRepoJson = strLstDup(argListMultiRepo);
         hrnCfgArgRawZ(argListMultiRepoJson, cfgOptOutput, "json");
+
+        StringList *argListMultiRepoProgressOnly = strLstDup(argListMultiRepo);
+        hrnCfgArgRawZ(argListMultiRepoProgressOnly, cfgOptProgressOnly, "y");
+
+        StringList *argListMultiRepoJsonProgressOnly = strLstDup(argListMultiRepoJson);
+        hrnCfgArgRawZ(argListMultiRepoJsonProgressOnly, cfgOptProgressOnly, "y");
 
         HRN_FORK_BEGIN()
         {
@@ -1914,6 +2071,59 @@ testRun(void)
                     // {uncrustify_on}
                     "json - multiple stanzas, some with valid backups, archives in latest DB, backup lock held on one stanza");
 
+                HRN_CFG_LOAD(cfgCmdInfo, argListMultiRepoJsonProgressOnly);
+                TEST_RESULT_STR_Z(
+                    infoRender(),
+                    // {uncrustify_off - indentation}
+                    "["
+                        "{"
+                            "\"name\":\"stanza1\","
+                            "\"status\":{"
+                                "\"code\":0,"
+                                "\"lock\":{"
+                                    "\"backup\":{\"held\":false},"
+                                    "\"restore\":{\"held\":false}"
+                                "},"
+                                "\"message\":\"ok\""
+                            "}"
+                        "},"
+                        "{"
+                            "\"name\":\"stanza2\","
+                            "\"status\":{"
+                                "\"code\":0,"
+                                "\"lock\":{"
+                                    "\"backup\":{\"held\":true,\"size\":3159000,\"size-cplt\":1435765},"
+                                    "\"restore\":{\"held\":false}"
+                                "},"
+                                "\"message\":\"ok\""
+                            "}"
+                        "},"
+                        "{"
+                            "\"name\":\"stanza3\","
+                            "\"status\":{"
+                                "\"code\":0,"
+                                "\"lock\":{"
+                                    "\"backup\":{\"held\":false},"
+                                    "\"restore\":{\"held\":false}"
+                                "},"
+                                "\"message\":\"ok\""
+                            "}"
+                        "},"
+                        "{"
+                            "\"name\":\"stanza4\","
+                            "\"status\":{"
+                                "\"code\":0,"
+                                "\"lock\":{"
+                                    "\"backup\":{\"held\":false},"
+                                    "\"restore\":{\"held\":true,\"size\":3159000,\"size-cplt\":389820}"
+                                "},"
+                                "\"message\":\"ok\""
+                            "}"
+                        "}"
+                    "]",
+                    // {uncrustify_on}
+                    "json (progress only) - multiple stanzas, some with valid backups, archives in latest DB, backup lock held on one stanza");
+
                 // Notify child to release lock
                 HRN_FORK_PARENT_NOTIFY_PUT(0);
                 HRN_FORK_PARENT_NOTIFY_PUT(1);
@@ -2056,6 +2266,22 @@ testRun(void)
                     "    db (current)\n"
                     "        wal archive min/max (9.4): none present\n",
                     "text - multiple stanzas, multi-repo with valid backups, backup lock held on one stanza");
+
+                HRN_CFG_LOAD(cfgCmdInfo, argListMultiRepoProgressOnly);
+                TEST_RESULT_STR_Z(
+                    infoRender(),
+                    "stanza: stanza1\n"
+                    "    status: ok\n"
+                    "\n"
+                    "stanza: stanza2\n"
+                    "    status: ok (backup/expire running - 55.55% complete)\n"
+                    "\n"
+                    "stanza: stanza3\n"
+                    "    status: ok\n"
+                    "\n"
+                    "stanza: stanza4\n"
+                    "    status: ok (restore running - 12.34% complete)\n",
+                    "text (progress only) - multiple stanzas, multi-repo with valid backups, backup lock held on one stanza");
 
                 // Notify child to release lock
                 HRN_FORK_PARENT_NOTIFY_PUT(0);
@@ -3853,6 +4079,16 @@ testRun(void)
             "    cipher: none\n",
             "text - invalid stanza");
 
+        StringList *argListProgressOnly = strLstDup(argList);
+        hrnCfgArgRawZ(argListProgressOnly, cfgOptProgressOnly, "y");
+        HRN_CFG_LOAD(cfgCmdInfo, argListProgressOnly);
+
+        TEST_RESULT_STR_Z(
+            infoRender(),
+            "stanza: [invalid]\n"
+            "    status: error (other)\n",
+            "text (progress only) - invalid stanza");
+
         hrnCfgArgRawZ(argList, cfgOptOutput, "json");
         HRN_CFG_LOAD(cfgCmdInfo, argList);
 
@@ -3890,6 +4126,28 @@ testRun(void)
             // {uncrustify_on}
             "json - invalid stanza");
 
+        hrnCfgArgRawZ(argListProgressOnly, cfgOptOutput, "json");
+        HRN_CFG_LOAD(cfgCmdInfo, argListProgressOnly);
+
+        TEST_RESULT_STR_Z(
+            infoRender(),
+            // {uncrustify_off - indentation}
+            "["
+                "{"
+                    "\"name\":\"[invalid]\","
+                    "\"status\":{"
+                        "\"code\":99,"
+                        "\"lock\":{"
+                            "\"backup\":{\"held\":false},"
+                            "\"restore\":{\"held\":false}"
+                        "},"
+                        "\"message\":\"other\""
+                    "}"
+                "}"
+            "]",
+            // {uncrustify_on}
+            "json (progress only) - invalid stanza");
+
         argList = strLstNew();
         hrnCfgArgKeyRawZ(argList, cfgOptRepoPath, 1, TEST_PATH "/repo2");
         hrnCfgArgRawZ(argList, cfgOptStanza, "stanza1");
@@ -3902,6 +4160,16 @@ testRun(void)
             "            [PathOpenError] unable to list file info for path '" TEST_PATH "/repo2/backup': [13] Permission denied\n"
             "    cipher: none\n",
             "text - stanza requested");
+
+        argListProgressOnly = strLstDup(argList);
+        hrnCfgArgRawZ(argListProgressOnly, cfgOptProgressOnly, "y");
+        HRN_CFG_LOAD(cfgCmdInfo, argListProgressOnly);
+
+        TEST_RESULT_STR_Z(
+            infoRender(),
+            "stanza: stanza1\n"
+            "    status: error (other)\n",
+            "text (progress only) - stanza requested");
 
         hrnCfgArgKeyRawZ(argList, cfgOptRepoPath, 2, TEST_PATH "/repo");
         HRN_CFG_LOAD(cfgCmdInfo, argList);
@@ -3916,6 +4184,15 @@ testRun(void)
             "        repo2: error (missing stanza path)\n"
             "    cipher: none\n",
             "text - stanza repo structure exists");
+
+        hrnCfgArgKeyRawZ(argListProgressOnly, cfgOptRepoPath, 2, TEST_PATH "/repo");
+        HRN_CFG_LOAD(cfgCmdInfo, argListProgressOnly);
+
+        TEST_RESULT_STR_Z(
+            infoRender(),
+            "stanza: stanza1\n"
+            "    status: error (different across repos)\n",
+            "text (progress only) - stanza repo structure exists");
     }
 
     FUNCTION_HARNESS_RETURN_VOID();


### PR DESCRIPTION
The info command fetches backup.info, archive.info, and manifest files
from the repository. However, this operation may hang if a backup or
restore process is running in parallel. Since progress data is stored in
local lock files, accessing the repository is unnecessary when only
progress information is needed.

This patch introduces the --progress-only option, which restricts the
info command output to progress details without querying the repository.
The only remaining operations are scanning the folder structure to list
available stanzas and reading lock files.

Note: When using this option, the info command performs no additional
checks beyond verifying stanza availability.
