### PR TITLE
ADBM-2055: Fix verify --set error reporting

### DIFF
--- a/src/command/verify/verify.c
+++ b/src/command/verify/verify.c
@@ -1650,8 +1650,22 @@ verifyProcess(const bool verboseText)
             if (backupLabel != NULL)
             {
                 if (!regExpMatchOne(backupRegExpStr, backupLabel))
-                    THROW_FMT(OptionInvalidValueError, "'%s' is not a valid backup label format", strZ(backupLabel));
-                backupRegExpStr = strNewFmt("^%s$", strZ(backupLabel));
+                {
+                    if (json)
+                    {
+                        strLstAddFmt(errorList, "'%s' is not a valid backup label format", strZ(backupLabel));
+                    }
+                    else
+                    {
+                        strCatFmt(resultStr, "\n  '%s' is not a valid backup label format", strZ(backupLabel));
+                    }
+                    errorTotal++;
+                    backupRegExpStr = strNewZ("^$");
+                }
+                else
+                {
+                    backupRegExpStr = strNewFmt("^%s$", strZ(backupLabel));
+                }
             }
 
             // Get a list of backups in the repo sorted ascending
@@ -1662,7 +1676,17 @@ verifyProcess(const bool verboseText)
                 sortOrderAsc);
 
             if (backupLabel != NULL && strLstEmpty(jobData.backupList))
-                THROW_FMT(BackupSetInvalidError, "backup set %s is not valid", strZ(backupLabel));
+            {
+                if (json)
+                {
+                    strLstAddFmt(errorList, "Backup set %s is not valid", strZ(backupLabel));
+                }
+                else
+                {
+                    strCatFmt(resultStr, "\n  Backup set %s is not valid", strZ(backupLabel));
+                }
+                errorTotal++;
+            }
 
             // Get a list of archive Ids in the repo (e.g. 9.4-1, 10-2, etc) sorted ascending by the db-id (number after the dash)
             jobData.archiveIdList = strLstSort(

--- a/src/command/verify/verify.c
+++ b/src/command/verify/verify.c
@@ -1647,6 +1647,7 @@ verifyProcess(const bool verboseText)
             // Use backup label if specified via --set.
             const String *backupLabel = cfgOptionStrNull(cfgOptSet);
             const String *backupRegExpStr = backupRegExpP(.full = true, .differential = true, .incremental = true);
+            bool backupLabelInvalid = false;
             if (backupLabel != NULL)
             {
                 if (!regExpMatchOne(backupRegExpStr, backupLabel))
@@ -1660,7 +1661,7 @@ verifyProcess(const bool verboseText)
                         strCatFmt(resultStr, "\n  '%s' is not a valid backup label format", strZ(backupLabel));
                     }
                     errorTotal++;
-                    backupRegExpStr = strNewZ("^$");
+                    backupLabelInvalid = true;
                 }
                 else
                 {
@@ -1675,7 +1676,7 @@ verifyProcess(const bool verboseText)
                     .expression = backupRegExpStr),
                 sortOrderAsc);
 
-            if (backupLabel != NULL && strLstEmpty(jobData.backupList))
+            if (!backupLabelInvalid && backupLabel != NULL && strLstEmpty(jobData.backupList))
             {
                 if (json)
                 {
@@ -1686,6 +1687,7 @@ verifyProcess(const bool verboseText)
                     strCatFmt(resultStr, "\n  Backup set %s is not valid", strZ(backupLabel));
                 }
                 errorTotal++;
+                backupLabelInvalid = true;
             }
 
             // Get a list of archive Ids in the repo (e.g. 9.4-1, 10-2, etc) sorted ascending by the db-id (number after the dash)
@@ -1696,7 +1698,8 @@ verifyProcess(const bool verboseText)
                 sortOrderAsc);
 
             // Only begin processing if there are some archives or backups in the repo
-            if (!strLstEmpty(jobData.archiveIdList) || !strLstEmpty(jobData.backupList))
+            if ((!strLstEmpty(jobData.archiveIdList) || !strLstEmpty(jobData.backupList)) &&
+                !backupLabelInvalid)
             {
                 // Warn if there are no archives or there are no backups in the repo so that the callback need not try to
                 // distinguish between having processed all of the list or if the list was missing in the first place
@@ -1846,7 +1849,7 @@ verifyProcess(const bool verboseText)
                 // Report results
                 resultStr = verifyRender(jobData.archiveIdResultList, jobData.backupResultList, verboseText, json);
             }
-            else
+            else if (!backupLabelInvalid)
             {
                 if (!json)
                 {

--- a/src/command/verify/verify.c
+++ b/src/command/verify/verify.c
@@ -1670,11 +1670,16 @@ verifyProcess(const bool verboseText)
             }
 
             // Get a list of backups in the repo sorted ascending
-            jobData.backupList = strLstSort(
-                storageListP(
-                    storage, STORAGE_REPO_BACKUP_STR,
-                    .expression = backupRegExpStr),
-                sortOrderAsc);
+            if (!backupLabelInvalid)
+            {
+                jobData.backupList = strLstSort(
+                    storageListP(
+                        storage, STORAGE_REPO_BACKUP_STR,
+                        .expression = backupRegExpStr),
+                    sortOrderAsc);
+            }
+            else
+                jobData.backupList = strLstNew();
 
             if (!backupLabelInvalid && backupLabel != NULL && strLstEmpty(jobData.backupList))
             {
@@ -1691,15 +1696,19 @@ verifyProcess(const bool verboseText)
             }
 
             // Get a list of archive Ids in the repo (e.g. 9.4-1, 10-2, etc) sorted ascending by the db-id (number after the dash)
-            jobData.archiveIdList = strLstSort(
-                strLstComparatorSet(
-                    storageListP(storage, STORAGE_REPO_ARCHIVE_STR, .expression = STRDEF(REGEX_ARCHIVE_DIR_DB_VERSION)),
-                    archiveIdComparator),
-                sortOrderAsc);
+            if (!backupLabelInvalid)
+            {
+                jobData.archiveIdList = strLstSort(
+                    strLstComparatorSet(
+                        storageListP(storage, STORAGE_REPO_ARCHIVE_STR, .expression = STRDEF(REGEX_ARCHIVE_DIR_DB_VERSION)),
+                        archiveIdComparator),
+                    sortOrderAsc);
+            }
+            else
+                jobData.archiveIdList = strLstNew();
 
             // Only begin processing if there are some archives or backups in the repo
-            if ((!strLstEmpty(jobData.archiveIdList) || !strLstEmpty(jobData.backupList)) &&
-                !backupLabelInvalid)
+            if (!strLstEmpty(jobData.archiveIdList) || !strLstEmpty(jobData.backupList))
             {
                 // Warn if there are no archives or there are no backups in the repo so that the callback need not try to
                 // distinguish between having processed all of the list or if the list was missing in the first place

--- a/test/src/module/command/verifyTest.c
+++ b/test/src/module/command/verifyTest.c
@@ -2693,10 +2693,29 @@ testRun(void)
         hrnCfgArgRawZ(argList, cfgOptSet, "20181119-152900F_20181119-152910D");
         HRN_CFG_LOAD(cfgCmdVerify, argList);
 
-        TEST_ERROR(
+        TEST_RESULT_STR_Z(
             verifyProcess(cfgOptionBool(cfgOptVerbose)),
-            BackupSetInvalidError,
-            "backup set 20181119-152900F_20181119-152910D is not valid");
+            "stanza: db\n"
+            "status: error\n"
+            "  Backup set 20250116-083850F_20250116-085828I is not valid",
+            "--set with invalid backup label, text");
+
+        argList = strLstDup(argListBase);
+        hrnCfgArgRawZ(argList, cfgOptOutput, "json");
+        hrnCfgArgRawZ(argList, cfgOptVerbose, "y");
+        hrnCfgArgRawZ(argList, cfgOptSet, "20181119-152900F_20181119-152910D");
+        HRN_CFG_LOAD(cfgCmdVerify, argList);
+
+        TEST_RESULT_STR_Z(
+            verifyProcess(cfgOptionBool(cfgOptVerbose)),
+            "{\n"
+            "  \"stanza\": \"seg0\",\n"
+            "  \"status\": \"error\",\n"
+            "  \"errors\": [\n"
+            "    \"Backup set 20250116-083850F_20250116-085828I is not valid\"\n"
+            "  ]\n"
+            "}",
+            "--set with invalid backup label, json");
 
         // -------------------------------------------------------------------------------------------------------------------------
         TEST_TITLE("--set with backup label of incorrect format");
@@ -2707,10 +2726,29 @@ testRun(void)
         hrnCfgArgRawZ(argList, cfgOptSet, "BOGUS");
         HRN_CFG_LOAD(cfgCmdVerify, argList);
 
-        TEST_ERROR(
+        TEST_RESULT_STR_Z(
             verifyProcess(cfgOptionBool(cfgOptVerbose)),
-            OptionInvalidValueError,
-            "'BOGUS' is not a valid backup label format");
+            "stanza: db\n"
+            "status: error\n"
+            "  'BOGUS' is not a valid backup label format",
+            "--set with backup label of incorrect format, text");
+        
+        argList = strLstDup(argListBase);
+        hrnCfgArgRawZ(argList, cfgOptOutput, "json");
+        hrnCfgArgRawZ(argList, cfgOptVerbose, "y");
+        hrnCfgArgRawZ(argList, cfgOptSet, "BOGUS");
+        HRN_CFG_LOAD(cfgCmdVerify, argList);
+
+        TEST_RESULT_STR_Z(
+            verifyProcess(cfgOptionBool(cfgOptVerbose)),
+            "{\n"
+            "  \"stanza\": \"seg0\",\n"
+            "  \"status\": \"error\",\n"
+            "  \"errors\": [\n"
+            "    \"'BOGUS' is not a valid backup label format\"\n"
+            "  ]\n"
+            "}",
+            "--set with backup label of incorrect format, json");
     }
 
     FUNCTION_HARNESS_RETURN_VOID();

--- a/test/src/module/command/verifyTest.c
+++ b/test/src/module/command/verifyTest.c
@@ -2697,7 +2697,7 @@ testRun(void)
             verifyProcess(cfgOptionBool(cfgOptVerbose)),
             "stanza: db\n"
             "status: error\n"
-            "  Backup set 20250116-083850F_20250116-085828I is not valid",
+            "  Backup set 20181119-152900F_20181119-152910D is not valid",
             "--set with invalid backup label, text");
 
         argList = strLstDup(argListBase);
@@ -2712,7 +2712,7 @@ testRun(void)
             "  \"stanza\": \"seg0\",\n"
             "  \"status\": \"error\",\n"
             "  \"errors\": [\n"
-            "    \"Backup set 20250116-083850F_20250116-085828I is not valid\"\n"
+            "    \"Backup set 20181119-152900F_20181119-152910D is not valid\"\n"
             "  ]\n"
             "}",
             "--set with invalid backup label, json");
@@ -2732,7 +2732,7 @@ testRun(void)
             "status: error\n"
             "  'BOGUS' is not a valid backup label format",
             "--set with backup label of incorrect format, text");
-        
+
         argList = strLstDup(argListBase);
         hrnCfgArgRawZ(argList, cfgOptOutput, "json");
         hrnCfgArgRawZ(argList, cfgOptVerbose, "y");

--- a/test/src/module/command/verifyTest.c
+++ b/test/src/module/command/verifyTest.c
@@ -2709,12 +2709,12 @@ testRun(void)
         TEST_RESULT_STR_Z(
             verifyProcess(cfgOptionBool(cfgOptVerbose)),
             "{\n"
-            "  \"stanza\": \"seg0\",\n"
+            "  \"stanza\": \"db\",\n"
             "  \"status\": \"error\",\n"
             "  \"errors\": [\n"
             "    \"Backup set 20181119-152900F_20181119-152910D is not valid\"\n"
             "  ]\n"
-            "}",
+            "}\n",
             "--set with invalid backup label, json");
 
         // -------------------------------------------------------------------------------------------------------------------------
@@ -2742,12 +2742,12 @@ testRun(void)
         TEST_RESULT_STR_Z(
             verifyProcess(cfgOptionBool(cfgOptVerbose)),
             "{\n"
-            "  \"stanza\": \"seg0\",\n"
+            "  \"stanza\": \"db\",\n"
             "  \"status\": \"error\",\n"
             "  \"errors\": [\n"
             "    \"'BOGUS' is not a valid backup label format\"\n"
             "  ]\n"
-            "}",
+            "}\n",
             "--set with backup label of incorrect format, json");
     }
 


### PR DESCRIPTION
Fix verify --set error reporting

Make the error reports for invalid backup labels go through the usual route
during pgbackrest verify. All other errors are reported either by printing to
resultStr in case of text output, or by adding it to errorList in case of
JSON. Previously backup label errors were throwing exceptions, which bypassed
the error printing logic and resulted in incorrect output.

Since it's still true that backups and archives should not be verified if
--set is specified incorrectly, a new backupLabelInvalid flag is used to skip
the main verification logic if backup label error is present.