### PR TITLE
 ADBM-2138 Implement alternative approach to optimize pgbackrest info

### DIFF
--- a/src/build/config/config.yaml
+++ b/src/build/config/config.yaml
@@ -399,6 +399,14 @@ option:
     command-role:
       main: {}
 
+  skip-wal-range:
+    type: boolean
+    default: false
+    command:
+      info: {}
+    command-role:
+      main: {}
+
   stanza:
     type: string
     command:

--- a/src/build/config/config.yaml
+++ b/src/build/config/config.yaml
@@ -399,14 +399,6 @@ option:
     command-role:
       main: {}
 
-  skip-wal-range:
-    type: boolean
-    default: false
-    command:
-      info: {}
-    command-role:
-      main: {}
-
   stanza:
     type: string
     command:
@@ -540,6 +532,15 @@ option:
     default: false
     command:
      verify: {}
+    command-role:
+      main: {}
+
+  wal-range:
+    type: boolean
+    default: true
+    negate: true
+    command:
+      info: {}
     command-role:
       main: {}
 

--- a/src/build/help/help.xml
+++ b/src/build/help/help.xml
@@ -2614,6 +2614,16 @@
                         <example>20150131-153358F_20150131-153401I</example>
                     </option>
 
+                    <option id="skip-wal-range" name="Skip Wal Range">
+                        <summary>Skip the scanning of WAL ranges.</summary>
+
+                        <text>
+                            <p>Enabling this option skips scanning for write-ahead log (WAL) archives during the execution of the info command. It reduces execution time and resource usage.</p>
+                        </text>
+
+                        <example>y</example>
+                    </option>
+
                     <option id="type" name="Type">
                         <summary>Filter on backup type.</summary>
 

--- a/src/build/help/help.xml
+++ b/src/build/help/help.xml
@@ -2614,16 +2614,6 @@
                         <example>20150131-153358F_20150131-153401I</example>
                     </option>
 
-                    <option id="skip-wal-range" name="Skip Wal Range">
-                        <summary>Skip the scanning of WAL ranges.</summary>
-
-                        <text>
-                            <p>Enabling this option skips scanning for write-ahead log (WAL) archives during the execution of the info command. It reduces execution time and resource usage.</p>
-                        </text>
-
-                        <example>y</example>
-                    </option>
-
                     <option id="type" name="Type">
                         <summary>Filter on backup type.</summary>
 
@@ -2633,6 +2623,17 @@
 
                         <example>full</example>
                     </option>
+
+                    <option id="wal-range" name="WAL Range">
+                        <summary>Scan for WAL ranges.</summary>
+
+                        <text>
+                            <p>Disabling this option skips scanning for write-ahead log (WAL) archives during the execution of the info command. This can significantly reduce execution time and resource usage.</p>
+                        </text>
+
+                        <example>n</example>
+                    </option>
+
                 </option-list>
             </command>
 

--- a/src/command/info/info.c
+++ b/src/command/info/info.c
@@ -333,7 +333,7 @@ Set the data for the archive section of the stanza for the database info from th
 static void
 archiveDbList(
     const String *const stanza, const InfoPgData *const pgData, VariantList *const archiveSection, const InfoArchive *const info,
-    const bool currentDb, const unsigned int repoIdx, const unsigned int repoKey, const bool skipWalRange)
+    const bool currentDb, const unsigned int repoIdx, const unsigned int repoKey, const bool walRange)
 {
     FUNCTION_TEST_BEGIN();
         FUNCTION_TEST_PARAM(STRING, stanza);
@@ -342,7 +342,7 @@ archiveDbList(
         FUNCTION_TEST_PARAM(BOOL, currentDb);
         FUNCTION_TEST_PARAM(UINT, repoIdx);
         FUNCTION_TEST_PARAM(UINT, repoKey);
-        FUNCTION_TEST_PARAM(BOOL, skipWalRange);
+        FUNCTION_TEST_PARAM(BOOL, walRange);
     FUNCTION_TEST_END();
 
     FUNCTION_AUDIT_HELPER();
@@ -362,7 +362,7 @@ archiveDbList(
     Variant *const archiveInfo = varNewKv(kvNew());
     const Storage *const storageRepo = storageRepoIdx(repoIdx);
 
-    if (!skipWalRange)
+    if (walRange)
     {
         // Get a list of WAL directories in the archive repo from oldest to newest, if any exist
         const StringList *const walDir = strLstSort(
@@ -711,7 +711,7 @@ Set the stanza data for each stanza found in the repo
 static VariantList *
 stanzaInfoList(
     List *const stanzaRepoList, const String *const backupLabel, const unsigned int repoIdxMin,
-    const unsigned int repoIdxMax, const bool progressOnly, const bool skipWalRange)
+    const unsigned int repoIdxMax, const bool progressOnly, const bool walRange)
 {
     FUNCTION_TEST_BEGIN();
         FUNCTION_TEST_PARAM(LIST, stanzaRepoList);
@@ -719,7 +719,7 @@ stanzaInfoList(
         FUNCTION_TEST_PARAM(UINT, repoIdxMin);
         FUNCTION_TEST_PARAM(UINT, repoIdxMax);
         FUNCTION_TEST_PARAM(BOOL, progressOnly);
-        FUNCTION_TEST_PARAM(BOOL, skipWalRange);
+        FUNCTION_TEST_PARAM(BOOL, walRange);
     FUNCTION_TEST_END();
 
     FUNCTION_AUDIT_HELPER();
@@ -796,7 +796,7 @@ stanzaInfoList(
                         // Get the archive info for the DB from the archive.info file
                         archiveDbList(
                             stanzaData->name, &pgData, archiveSection, repoData->archiveInfo, (pgIdx == 0 ? true : false),
-                            repoIdx, repoData->key, skipWalRange);
+                            repoIdx, repoData->key, walRange);
                     }
 
                     // Set stanza status if the current db sections do not match across repos
@@ -1431,8 +1431,8 @@ infoRender(void)
         // Is only progress output requested?
         const bool progressOnly = cfgOptionBool(cfgOptProgressOnly);
 
-        // Skip the scan of WAL ranges?
-        const bool skipWalRange = cfgOptionBool(cfgOptSkipWalRange);
+        // Is the scan of WAL ranges needed?
+        const bool walRange = cfgOptionBool(cfgOptWalRange);
 
         // Get stanza if specified
         const String *const stanza = cfgOptionStrNull(cfgOptStanza);
@@ -1619,7 +1619,7 @@ infoRender(void)
 
         // If the backup storage exists, then search for and process any stanzas
         if (!lstEmpty(stanzaRepoList))
-            infoList = stanzaInfoList(stanzaRepoList, backupLabel, repoIdxMin, repoIdxMax, progressOnly, skipWalRange);
+            infoList = stanzaInfoList(stanzaRepoList, backupLabel, repoIdxMin, repoIdxMax, progressOnly, walRange);
 
         // Format text output
         if (cfgOptionStrId(cfgOptOutput) == CFGOPTVAL_OUTPUT_TEXT)

--- a/src/command/info/info.c
+++ b/src/command/info/info.c
@@ -374,8 +374,7 @@ archiveDbList(
             for (unsigned int idx = 0; idx < strLstSize(walDir); idx++)
             {
                 // Get a list of all WAL in this WAL dir and sort the list from oldest to newest to get the oldest starting WAL
-                // archived
-                // for this db
+                // archived for this db
                 const StringList *const list = strLstSort(
                     storageListP(
                         storageRepo, strNewFmt("%s/%s", strZ(archivePath), strZ(strLstGet(walDir, idx))),
@@ -394,8 +393,7 @@ archiveDbList(
             for (unsigned int idx = strLstSize(walDir) - 1; (int)idx >= 0; idx--)
             {
                 // Get a list of all WAL in this WAL dir and sort the list from newest to oldest to get the newest ending WAL
-                // archived
-                // for this db
+                // archived for this db
                 const StringList *const list = strLstSort(
                     storageListP(
                         storageRepo, strNewFmt("%s/%s", strZ(archivePath), strZ(strLstGet(walDir, idx))),

--- a/src/command/info/info.c
+++ b/src/command/info/info.c
@@ -333,7 +333,7 @@ Set the data for the archive section of the stanza for the database info from th
 static void
 archiveDbList(
     const String *const stanza, const InfoPgData *const pgData, VariantList *const archiveSection, const InfoArchive *const info,
-    const bool currentDb, const unsigned int repoIdx, const unsigned int repoKey)
+    const bool currentDb, const unsigned int repoIdx, const unsigned int repoKey, const bool skipWalRange)
 {
     FUNCTION_TEST_BEGIN();
         FUNCTION_TEST_PARAM(STRING, stanza);
@@ -342,6 +342,7 @@ archiveDbList(
         FUNCTION_TEST_PARAM(BOOL, currentDb);
         FUNCTION_TEST_PARAM(UINT, repoIdx);
         FUNCTION_TEST_PARAM(UINT, repoKey);
+        FUNCTION_TEST_PARAM(BOOL, skipWalRange);
     FUNCTION_TEST_END();
 
     FUNCTION_AUDIT_HELPER();
@@ -361,47 +362,50 @@ archiveDbList(
     Variant *const archiveInfo = varNewKv(kvNew());
     const Storage *const storageRepo = storageRepoIdx(repoIdx);
 
-    // Get a list of WAL directories in the archive repo from oldest to newest, if any exist
-    const StringList *const walDir = strLstSort(
-        storageListP(storageRepo, archivePath, .expression = WAL_SEGMENT_DIR_REGEXP_STR), sortOrderAsc);
-
-    if (!strLstEmpty(walDir))
+    if(!skipWalRange)
     {
-        // Not every WAL dir has WAL files so check each
-        for (unsigned int idx = 0; idx < strLstSize(walDir); idx++)
-        {
-            // Get a list of all WAL in this WAL dir and sort the list from oldest to newest to get the oldest starting WAL archived
-            // for this db
-            const StringList *const list = strLstSort(
-                storageListP(
-                    storageRepo, strNewFmt("%s/%s", strZ(archivePath), strZ(strLstGet(walDir, idx))),
-                    .expression = WAL_SEGMENT_FILE_REGEXP_STR),
-                sortOrderAsc);
+        // Get a list of WAL directories in the archive repo from oldest to newest, if any exist
+        const StringList *const walDir = strLstSort(
+            storageListP(storageRepo, archivePath, .expression = WAL_SEGMENT_DIR_REGEXP_STR), sortOrderAsc);
 
-            // If wal segments are found, get the oldest one as the archive start
-            if (!strLstEmpty(list))
+        if (!strLstEmpty(walDir))
+        {
+            // Not every WAL dir has WAL files so check each
+            for (unsigned int idx = 0; idx < strLstSize(walDir); idx++)
             {
-                archiveStart = strSubN(strLstGet(list, 0), 0, 24);
-                break;
+                // Get a list of all WAL in this WAL dir and sort the list from oldest to newest to get the oldest starting WAL archived
+                // for this db
+                const StringList *const list = strLstSort(
+                    storageListP(
+                        storageRepo, strNewFmt("%s/%s", strZ(archivePath), strZ(strLstGet(walDir, idx))),
+                        .expression = WAL_SEGMENT_FILE_REGEXP_STR),
+                    sortOrderAsc);
+
+                // If wal segments are found, get the oldest one as the archive start
+                if (!strLstEmpty(list))
+                {
+                    archiveStart = strSubN(strLstGet(list, 0), 0, 24);
+                    break;
+                }
             }
-        }
 
-        // Iterate through the directory list in reverse processing newest first. Cast comparison to an int for readability.
-        for (unsigned int idx = strLstSize(walDir) - 1; (int)idx >= 0; idx--)
-        {
-            // Get a list of all WAL in this WAL dir and sort the list from newest to oldest to get the newest ending WAL archived
-            // for this db
-            const StringList *const list = strLstSort(
-                storageListP(
-                    storageRepo, strNewFmt("%s/%s", strZ(archivePath), strZ(strLstGet(walDir, idx))),
-                    .expression = WAL_SEGMENT_FILE_REGEXP_STR),
-                sortOrderDesc);
-
-            // If wal segments are found, get the newest one as the archive stop
-            if (!strLstEmpty(list))
+            // Iterate through the directory list in reverse processing newest first. Cast comparison to an int for readability.
+            for (unsigned int idx = strLstSize(walDir) - 1; (int)idx >= 0; idx--)
             {
-                archiveStop = strSubN(strLstGet(list, 0), 0, 24);
-                break;
+                // Get a list of all WAL in this WAL dir and sort the list from newest to oldest to get the newest ending WAL archived
+                // for this db
+                const StringList *const list = strLstSort(
+                    storageListP(
+                        storageRepo, strNewFmt("%s/%s", strZ(archivePath), strZ(strLstGet(walDir, idx))),
+                        .expression = WAL_SEGMENT_FILE_REGEXP_STR),
+                    sortOrderDesc);
+
+                // If wal segments are found, get the newest one as the archive stop
+                if (!strLstEmpty(list))
+                {
+                    archiveStop = strSubN(strLstGet(list, 0), 0, 24);
+                    break;
+                }
             }
         }
     }
@@ -707,7 +711,7 @@ Set the stanza data for each stanza found in the repo
 static VariantList *
 stanzaInfoList(
     List *const stanzaRepoList, const String *const backupLabel, const unsigned int repoIdxMin,
-    const unsigned int repoIdxMax, const bool progressOnly)
+    const unsigned int repoIdxMax, const bool progressOnly, const bool skipWalRange)
 {
     FUNCTION_TEST_BEGIN();
         FUNCTION_TEST_PARAM(LIST, stanzaRepoList);
@@ -715,6 +719,7 @@ stanzaInfoList(
         FUNCTION_TEST_PARAM(UINT, repoIdxMin);
         FUNCTION_TEST_PARAM(UINT, repoIdxMax);
         FUNCTION_TEST_PARAM(BOOL, progressOnly);
+        FUNCTION_TEST_PARAM(BOOL, skipWalRange);
     FUNCTION_TEST_END();
 
     FUNCTION_AUDIT_HELPER();
@@ -791,7 +796,7 @@ stanzaInfoList(
                         // Get the archive info for the DB from the archive.info file
                         archiveDbList(
                             stanzaData->name, &pgData, archiveSection, repoData->archiveInfo, (pgIdx == 0 ? true : false),
-                            repoIdx, repoData->key);
+                            repoIdx, repoData->key, skipWalRange);
                     }
 
                     // Set stanza status if the current db sections do not match across repos
@@ -1426,6 +1431,9 @@ infoRender(void)
         // Is only progress output requested?
         const bool progressOnly = cfgOptionBool(cfgOptProgressOnly);
 
+        // Skip the scan of WAL ranges?
+        const bool skipWalRange = cfgOptionBool(cfgOptSkipWalRange);
+
         // Get stanza if specified
         const String *const stanza = cfgOptionStrNull(cfgOptStanza);
 
@@ -1611,7 +1619,7 @@ infoRender(void)
 
         // If the backup storage exists, then search for and process any stanzas
         if (!lstEmpty(stanzaRepoList))
-            infoList = stanzaInfoList(stanzaRepoList, backupLabel, repoIdxMin, repoIdxMax, progressOnly);
+            infoList = stanzaInfoList(stanzaRepoList, backupLabel, repoIdxMin, repoIdxMax, progressOnly, skipWalRange);
 
         // Format text output
         if (cfgOptionStrId(cfgOptOutput) == CFGOPTVAL_OUTPUT_TEXT)

--- a/src/command/info/info.c
+++ b/src/command/info/info.c
@@ -362,7 +362,7 @@ archiveDbList(
     Variant *const archiveInfo = varNewKv(kvNew());
     const Storage *const storageRepo = storageRepoIdx(repoIdx);
 
-    if(!skipWalRange)
+    if (!skipWalRange)
     {
         // Get a list of WAL directories in the archive repo from oldest to newest, if any exist
         const StringList *const walDir = strLstSort(
@@ -373,7 +373,8 @@ archiveDbList(
             // Not every WAL dir has WAL files so check each
             for (unsigned int idx = 0; idx < strLstSize(walDir); idx++)
             {
-                // Get a list of all WAL in this WAL dir and sort the list from oldest to newest to get the oldest starting WAL archived
+                // Get a list of all WAL in this WAL dir and sort the list from oldest to newest to get the oldest starting WAL
+                // archived
                 // for this db
                 const StringList *const list = strLstSort(
                     storageListP(
@@ -392,7 +393,8 @@ archiveDbList(
             // Iterate through the directory list in reverse processing newest first. Cast comparison to an int for readability.
             for (unsigned int idx = strLstSize(walDir) - 1; (int)idx >= 0; idx--)
             {
-                // Get a list of all WAL in this WAL dir and sort the list from newest to oldest to get the newest ending WAL archived
+                // Get a list of all WAL in this WAL dir and sort the list from newest to oldest to get the newest ending WAL
+                // archived
                 // for this db
                 const StringList *const list = strLstSort(
                     storageListP(

--- a/src/config/config.auto.h
+++ b/src/config/config.auto.h
@@ -115,6 +115,7 @@ Option constants
 #define CFGOPT_SCK_BLOCK                                            "sck-block"
 #define CFGOPT_SCK_KEEP_ALIVE                                       "sck-keep-alive"
 #define CFGOPT_SET                                                  "set"
+#define CFGOPT_SKIP_WAL_RANGE                                       "skip-wal-range"
 #define CFGOPT_SORT                                                 "sort"
 #define CFGOPT_SPOOL_PATH                                           "spool-path"
 #define CFGOPT_STANZA                                               "stanza"
@@ -138,7 +139,7 @@ Option constants
 #define CFGOPT_TYPE                                                 "type"
 #define CFGOPT_VERBOSE                                              "verbose"
 
-#define CFG_OPTION_TOTAL                                            182
+#define CFG_OPTION_TOTAL                                            183
 
 /***********************************************************************************************************************************
 Option value constants
@@ -551,6 +552,7 @@ typedef enum
     cfgOptSckBlock,
     cfgOptSckKeepAlive,
     cfgOptSet,
+    cfgOptSkipWalRange,
     cfgOptSort,
     cfgOptSpoolPath,
     cfgOptStanza,

--- a/src/config/config.auto.h
+++ b/src/config/config.auto.h
@@ -115,7 +115,6 @@ Option constants
 #define CFGOPT_SCK_BLOCK                                            "sck-block"
 #define CFGOPT_SCK_KEEP_ALIVE                                       "sck-keep-alive"
 #define CFGOPT_SET                                                  "set"
-#define CFGOPT_SKIP_WAL_RANGE                                       "skip-wal-range"
 #define CFGOPT_SORT                                                 "sort"
 #define CFGOPT_SPOOL_PATH                                           "spool-path"
 #define CFGOPT_STANZA                                               "stanza"
@@ -138,6 +137,7 @@ Option constants
 #define CFGOPT_TLS_SERVER_PORT                                      "tls-server-port"
 #define CFGOPT_TYPE                                                 "type"
 #define CFGOPT_VERBOSE                                              "verbose"
+#define CFGOPT_WAL_RANGE                                            "wal-range"
 
 #define CFG_OPTION_TOTAL                                            183
 
@@ -552,7 +552,6 @@ typedef enum
     cfgOptSckBlock,
     cfgOptSckKeepAlive,
     cfgOptSet,
-    cfgOptSkipWalRange,
     cfgOptSort,
     cfgOptSpoolPath,
     cfgOptStanza,
@@ -575,6 +574,7 @@ typedef enum
     cfgOptTlsServerPort,
     cfgOptType,
     cfgOptVerbose,
+    cfgOptWalRange,
 } ConfigOption;
 
 #endif

--- a/src/config/parse.auto.c.inc
+++ b/src/config/parse.auto.c.inc
@@ -9891,30 +9891,6 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         ),                                                                                                                // opt/set
     ),                                                                                                                    // opt/set
     // -----------------------------------------------------------------------------------------------------------------------------
-    PARSE_RULE_OPTION                                                                                          // opt/skip-wal-range
-    (                                                                                                          // opt/skip-wal-range
-        PARSE_RULE_OPTION_NAME("skip-wal-range"),                                                              // opt/skip-wal-range
-        PARSE_RULE_OPTION_TYPE(cfgOptTypeBoolean),                                                             // opt/skip-wal-range
-        PARSE_RULE_OPTION_REQUIRED(true),                                                                      // opt/skip-wal-range
-        PARSE_RULE_OPTION_SECTION(cfgSectionCommandLine),                                                      // opt/skip-wal-range
-                                                                                                               // opt/skip-wal-range
-        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST                                                         // opt/skip-wal-range
-        (                                                                                                      // opt/skip-wal-range
-            PARSE_RULE_OPTION_COMMAND(cfgCmdInfo)                                                              // opt/skip-wal-range
-        ),                                                                                                     // opt/skip-wal-range
-                                                                                                               // opt/skip-wal-range
-        PARSE_RULE_OPTIONAL                                                                                    // opt/skip-wal-range
-        (                                                                                                      // opt/skip-wal-range
-            PARSE_RULE_OPTIONAL_GROUP                                                                          // opt/skip-wal-range
-            (                                                                                                  // opt/skip-wal-range
-                PARSE_RULE_OPTIONAL_DEFAULT                                                                    // opt/skip-wal-range
-                (                                                                                              // opt/skip-wal-range
-                    PARSE_RULE_VAL_BOOL_FALSE,                                                                 // opt/skip-wal-range
-                ),                                                                                             // opt/skip-wal-range
-            ),                                                                                                 // opt/skip-wal-range
-        ),                                                                                                     // opt/skip-wal-range
-    ),                                                                                                         // opt/skip-wal-range
-    // -----------------------------------------------------------------------------------------------------------------------------
     PARSE_RULE_OPTION                                                                                                    // opt/sort
     (                                                                                                                    // opt/sort
         PARSE_RULE_OPTION_NAME("sort"),                                                                                  // opt/sort
@@ -10792,6 +10768,31 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
             ),                                                                                                        // opt/verbose
         ),                                                                                                            // opt/verbose
     ),                                                                                                                // opt/verbose
+    // -----------------------------------------------------------------------------------------------------------------------------
+    PARSE_RULE_OPTION                                                                                               // opt/wal-range
+    (                                                                                                               // opt/wal-range
+        PARSE_RULE_OPTION_NAME("wal-range"),                                                                        // opt/wal-range
+        PARSE_RULE_OPTION_TYPE(cfgOptTypeBoolean),                                                                  // opt/wal-range
+        PARSE_RULE_OPTION_NEGATE(true),                                                                             // opt/wal-range
+        PARSE_RULE_OPTION_REQUIRED(true),                                                                           // opt/wal-range
+        PARSE_RULE_OPTION_SECTION(cfgSectionCommandLine),                                                           // opt/wal-range
+                                                                                                                    // opt/wal-range
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST                                                              // opt/wal-range
+        (                                                                                                           // opt/wal-range
+            PARSE_RULE_OPTION_COMMAND(cfgCmdInfo)                                                                   // opt/wal-range
+        ),                                                                                                          // opt/wal-range
+                                                                                                                    // opt/wal-range
+        PARSE_RULE_OPTIONAL                                                                                         // opt/wal-range
+        (                                                                                                           // opt/wal-range
+            PARSE_RULE_OPTIONAL_GROUP                                                                               // opt/wal-range
+            (                                                                                                       // opt/wal-range
+                PARSE_RULE_OPTIONAL_DEFAULT                                                                         // opt/wal-range
+                (                                                                                                   // opt/wal-range
+                    PARSE_RULE_VAL_BOOL_TRUE,                                                                       // opt/wal-range
+                ),                                                                                                  // opt/wal-range
+            ),                                                                                                      // opt/wal-range
+        ),                                                                                                          // opt/wal-range
+    ),                                                                                                              // opt/wal-range
 };
 
 /***********************************************************************************************************************************
@@ -11139,7 +11140,6 @@ static const uint8_t optionResolveOrder[] =
     cfgOptSckBlock,                                                                                             // opt-resolve-order
     cfgOptSckKeepAlive,                                                                                         // opt-resolve-order
     cfgOptSet,                                                                                                  // opt-resolve-order
-    cfgOptSkipWalRange,                                                                                         // opt-resolve-order
     cfgOptSort,                                                                                                 // opt-resolve-order
     cfgOptSpoolPath,                                                                                            // opt-resolve-order
     cfgOptStartFast,                                                                                            // opt-resolve-order
@@ -11157,6 +11157,7 @@ static const uint8_t optionResolveOrder[] =
     cfgOptTlsServerPort,                                                                                        // opt-resolve-order
     cfgOptType,                                                                                                 // opt-resolve-order
     cfgOptVerbose,                                                                                              // opt-resolve-order
+    cfgOptWalRange,                                                                                             // opt-resolve-order
     cfgOptArchiveCheck,                                                                                         // opt-resolve-order
     cfgOptArchiveCopy,                                                                                          // opt-resolve-order
     cfgOptArchiveModeCheck,                                                                                     // opt-resolve-order

--- a/src/config/parse.auto.c.inc
+++ b/src/config/parse.auto.c.inc
@@ -9891,6 +9891,30 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         ),                                                                                                                // opt/set
     ),                                                                                                                    // opt/set
     // -----------------------------------------------------------------------------------------------------------------------------
+    PARSE_RULE_OPTION                                                                                          // opt/skip-wal-range
+    (                                                                                                          // opt/skip-wal-range
+        PARSE_RULE_OPTION_NAME("skip-wal-range"),                                                              // opt/skip-wal-range
+        PARSE_RULE_OPTION_TYPE(cfgOptTypeBoolean),                                                             // opt/skip-wal-range
+        PARSE_RULE_OPTION_REQUIRED(true),                                                                      // opt/skip-wal-range
+        PARSE_RULE_OPTION_SECTION(cfgSectionCommandLine),                                                      // opt/skip-wal-range
+                                                                                                               // opt/skip-wal-range
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST                                                         // opt/skip-wal-range
+        (                                                                                                      // opt/skip-wal-range
+            PARSE_RULE_OPTION_COMMAND(cfgCmdInfo)                                                              // opt/skip-wal-range
+        ),                                                                                                     // opt/skip-wal-range
+                                                                                                               // opt/skip-wal-range
+        PARSE_RULE_OPTIONAL                                                                                    // opt/skip-wal-range
+        (                                                                                                      // opt/skip-wal-range
+            PARSE_RULE_OPTIONAL_GROUP                                                                          // opt/skip-wal-range
+            (                                                                                                  // opt/skip-wal-range
+                PARSE_RULE_OPTIONAL_DEFAULT                                                                    // opt/skip-wal-range
+                (                                                                                              // opt/skip-wal-range
+                    PARSE_RULE_VAL_BOOL_FALSE,                                                                 // opt/skip-wal-range
+                ),                                                                                             // opt/skip-wal-range
+            ),                                                                                                 // opt/skip-wal-range
+        ),                                                                                                     // opt/skip-wal-range
+    ),                                                                                                         // opt/skip-wal-range
+    // -----------------------------------------------------------------------------------------------------------------------------
     PARSE_RULE_OPTION                                                                                                    // opt/sort
     (                                                                                                                    // opt/sort
         PARSE_RULE_OPTION_NAME("sort"),                                                                                  // opt/sort
@@ -11115,6 +11139,7 @@ static const uint8_t optionResolveOrder[] =
     cfgOptSckBlock,                                                                                             // opt-resolve-order
     cfgOptSckKeepAlive,                                                                                         // opt-resolve-order
     cfgOptSet,                                                                                                  // opt-resolve-order
+    cfgOptSkipWalRange,                                                                                         // opt-resolve-order
     cfgOptSort,                                                                                                 // opt-resolve-order
     cfgOptSpoolPath,                                                                                            // opt-resolve-order
     cfgOptStartFast,                                                                                            // opt-resolve-order

--- a/test/src/module/command/infoTest.c
+++ b/test/src/module/command/infoTest.c
@@ -34,6 +34,12 @@ testRun(void)
         hrnCfgArgRawZ(argList, cfgOptOutput, "json");
         HRN_CFG_LOAD(cfgCmdInfo, argList);
 
+        StringList *argListSkipWalRange = strLstDup(argList);
+        hrnCfgArgRawZ(argListSkipWalRange, cfgOptSkipWalRange, "y");
+
+        StringList *argListTextSkipWalRange = strLstDup(argListText);
+        hrnCfgArgRawZ(argListTextSkipWalRange, cfgOptSkipWalRange, "y");
+
         StringList *argListProgressOnly = strLstDup(argList);
         hrnCfgArgRawZ(argListProgressOnly, cfgOptProgressOnly, "y");
 
@@ -818,6 +824,148 @@ testRun(void)
                     // {uncrustify_on}
                     "json - single stanza, valid backup, no priors, no archives in latest DB, backup/expire lock detected");
 
+                HRN_CFG_LOAD(cfgCmdInfo, argListSkipWalRange);
+                TEST_RESULT_STR_Z(
+                    infoRender(),
+                    // {uncrustify_off - indentation}
+                    "["
+                        "{"
+                             "\"archive\":["
+                                "{"
+                                    "\"database\":{"
+                                        "\"id\":1,"
+                                        "\"repo-key\":1"
+                                    "},"
+                                    "\"id\":\"9.6-1\","
+                                    "\"max\":null,"
+                                    "\"min\":null"
+                                "},"
+                                "{"
+                                    "\"database\":{"
+                                        "\"id\":2,"
+                                        "\"repo-key\":1"
+                                    "},"
+                                    "\"id\":\"9.5-2\","
+                                    "\"max\":null,"
+                                    "\"min\":null"
+                                "},"
+                                "{"
+                                    "\"database\":{"
+                                        "\"id\":3,"
+                                        "\"repo-key\":1"
+                                    "},"
+                                    "\"id\":\"9.6-3\","
+                                    "\"max\":null,"
+                                    "\"min\":null"
+                                "}"
+                            "],"
+                             "\"backup\":["
+                                "{"
+                                    "\"archive\":{"
+                                        "\"start\":null,"
+                                        "\"stop\":null"
+                                    "},"
+                                    "\"backrest\":{"
+                                        "\"format\":5,"
+                                        "\"version\":\"2.04\""
+                                    "},"
+                                    "\"database\":{"
+                                        "\"id\":1,"
+                                        "\"repo-key\":1"
+                                    "},"
+                                    "\"info\":{"
+                                        "\"delta\":26897030,"
+                                        "\"repository\":{"
+                                            "\"delta\":3159,"
+                                            "\"size\":3159776"
+                                        "},"
+                                        "\"size\":26897030"
+                                    "},"
+                                    "\"label\":\"20181116-154756F\","
+                                    "\"prior\":null,"
+                                    "\"reference\":null,"
+                                    "\"timestamp\":{"
+                                        "\"start\":1542383276,"
+                                        "\"stop\":1542383289"
+                                    "},"
+                                    "\"type\":\"full\""
+                                "},"
+                                "{"
+                                    "\"archive\":{"
+                                        "\"start\":\"000000030000000000000001\","
+                                        "\"stop\":\"000000030000000000000001\""
+                                    "},"
+                                    "\"backrest\":{"
+                                        "\"format\":5,"
+                                        "\"version\":\"2.30\""
+                                    "},"
+                                    "\"database\":{"
+                                        "\"id\":3,"
+                                        "\"repo-key\":1"
+                                    "},"
+                                    "\"info\":{"
+                                        "\"delta\":26897033,"
+                                        "\"repository\":{"
+                                            "\"delta\":3159,"
+                                            "\"size\":3159776"
+                                        "},"
+                                        "\"size\":26897033"
+                                    "},"
+                                    "\"label\":\"20201116-154900F\","
+                                    "\"prior\":null,"
+                                    "\"reference\":null,"
+                                    "\"timestamp\":{"
+                                        "\"start\":1605541676,"
+                                        "\"stop\":1605541680"
+                                    "},"
+                                    "\"type\":\"full\""
+                                "}"
+                            "],"
+                             "\"cipher\":\"none\","
+                             "\"db\":["
+                                "{"
+                                    "\"id\":1,"
+                                    "\"repo-key\":1,"
+                                    "\"system-id\":6569239123849665679,"
+                                    "\"version\":\"9.6\""
+                                "},"
+                                "{"
+                                    "\"id\":2,"
+                                    "\"repo-key\":1,"
+                                    "\"system-id\":6569239123849665666,"
+                                    "\"version\":\"9.5\""
+                                "},"
+                                "{"
+                                    "\"id\":3,"
+                                    "\"repo-key\":1,"
+                                    "\"system-id\":6569239123849665679,"
+                                    "\"version\":\"9.6\""
+                                "}"
+                            "],"
+                            "\"name\":\"stanza1\","
+                            "\"repo\":["
+                                "{"
+                                    "\"cipher\":\"none\","
+                                    "\"key\":1,"
+                                    "\"status\":{"
+                                        "\"code\":0,"
+                                        "\"message\":\"ok\""
+                                    "}"
+                                "}"
+                            "],"
+                            "\"status\":{"
+                                "\"code\":0,"
+                                "\"lock\":{"
+                                    "\"backup\":{\"held\":true},"
+                                    "\"restore\":{\"held\":false}"
+                                "},"
+                                "\"message\":\"ok\""
+                            "}"
+                        "}"
+                    "]",
+                    // {uncrustify_on}
+                    "json (skip wal range) - single stanza, valid backup, no priors, no archives in latest DB, backup/expire lock detected");
+
                 HRN_CFG_LOAD(cfgCmdInfo, argListProgressOnly);
                 TEST_RESULT_STR_Z(
                     infoRender(),
@@ -863,6 +1011,32 @@ testRun(void)
                     "            database size: 25.7MB, database backup size: 25.7MB\n"
                     "            repo1: backup set size: 3MB, backup size: 3KB\n",
                     "text - single stanza, valid backup, no priors, no archives in latest DB, backup/expire lock detected");
+
+                HRN_CFG_LOAD(cfgCmdInfo, argListTextSkipWalRange);
+                TEST_RESULT_STR_Z(
+                    infoRender(),
+                    "stanza: stanza1\n"
+                    "    status: ok (backup/expire running)\n"
+                    "    cipher: none\n"
+                    "\n"
+                    "    db (prior)\n"
+                    "        wal archive min/max (9.5): none present\n"
+                    "\n"
+                    "    db (current)\n"
+                    "        wal archive min/max (9.6): none present\n"
+                    "\n"
+                    "        full backup: 20181116-154756F\n"
+                    "            timestamp start/stop: 2018-11-16 15:47:56+00 / 2018-11-16 15:48:09+00\n"
+                    "            wal start/stop: n/a\n"
+                    "            database size: 25.7MB, database backup size: 25.7MB\n"
+                    "            repo1: backup set size: 3MB, backup size: 3KB\n"
+                    "\n"
+                    "        full backup: 20201116-154900F\n"
+                    "            timestamp start/stop: 2020-11-16 15:47:56+00 / 2020-11-16 15:48:00+00\n"
+                    "            wal start/stop: 000000030000000000000001 / 000000030000000000000001\n"
+                    "            database size: 25.7MB, database backup size: 25.7MB\n"
+                    "            repo1: backup set size: 3MB, backup size: 3KB\n",
+                    "text (skip wal range) - single stanza, valid backup, no priors, no archives in latest DB, backup/expire lock detected");
 
                 HRN_CFG_LOAD(cfgCmdInfo, argListTextProgressOnly);
                 TEST_RESULT_STR_Z(

--- a/test/src/module/command/infoTest.c
+++ b/test/src/module/command/infoTest.c
@@ -825,30 +825,16 @@ testRun(void)
                     "json - single stanza, valid backup, no priors, no archives in latest DB, backup/expire lock detected");
 
                 HRN_CFG_LOAD(cfgCmdInfo, argListSkipWalRange);
+                // Only the database with id=3 is displayed in the archive section because it is the only one associated with a
+                // backup that includes WAL archive information.
+                // Other databases are omitted due to the absence of WAL archives or backups, and the --skip-wal-range option
+                // prevents scanning for additional WAL files in the repository.
                 TEST_RESULT_STR_Z(
                     infoRender(),
                     // {uncrustify_off - indentation}
                     "["
                         "{"
                              "\"archive\":["
-                                "{"
-                                    "\"database\":{"
-                                        "\"id\":1,"
-                                        "\"repo-key\":1"
-                                    "},"
-                                    "\"id\":\"9.6-1\","
-                                    "\"max\":null,"
-                                    "\"min\":null"
-                                "},"
-                                "{"
-                                    "\"database\":{"
-                                        "\"id\":2,"
-                                        "\"repo-key\":1"
-                                    "},"
-                                    "\"id\":\"9.5-2\","
-                                    "\"max\":null,"
-                                    "\"min\":null"
-                                "},"
                                 "{"
                                     "\"database\":{"
                                         "\"id\":3,"
@@ -1012,15 +998,16 @@ testRun(void)
                     "            repo1: backup set size: 3MB, backup size: 3KB\n",
                     "text - single stanza, valid backup, no priors, no archives in latest DB, backup/expire lock detected");
 
+                // Display only the current database because no prior databases contain WAL archives or backups.
+                // The --skip-wal-range option prevents scanning for WAL files, so only databases explicitly linked to backups
+                // appear in the output.
+                // The full backup 20201116-154900F includes WAL start/stop information, making it the only visible archive.
                 HRN_CFG_LOAD(cfgCmdInfo, argListTextSkipWalRange);
                 TEST_RESULT_STR_Z(
                     infoRender(),
                     "stanza: stanza1\n"
                     "    status: ok (backup/expire running)\n"
                     "    cipher: none\n"
-                    "\n"
-                    "    db (prior)\n"
-                    "        wal archive min/max (9.5): none present\n"
                     "\n"
                     "    db (current)\n"
                     "        wal archive min/max (9.6): none present\n"

--- a/test/src/module/command/infoTest.c
+++ b/test/src/module/command/infoTest.c
@@ -34,11 +34,11 @@ testRun(void)
         hrnCfgArgRawZ(argList, cfgOptOutput, "json");
         HRN_CFG_LOAD(cfgCmdInfo, argList);
 
-        StringList *argListSkipWalRange = strLstDup(argList);
-        hrnCfgArgRawZ(argListSkipWalRange, cfgOptSkipWalRange, "y");
+        StringList *argListNoWalRange = strLstDup(argList);
+        hrnCfgArgRawZ(argListNoWalRange, cfgOptWalRange, "n");
 
-        StringList *argListTextSkipWalRange = strLstDup(argListText);
-        hrnCfgArgRawZ(argListTextSkipWalRange, cfgOptSkipWalRange, "y");
+        StringList *argListTextNoWalRange = strLstDup(argListText);
+        hrnCfgArgRawZ(argListTextNoWalRange, cfgOptWalRange, "n");
 
         StringList *argListProgressOnly = strLstDup(argList);
         hrnCfgArgRawZ(argListProgressOnly, cfgOptProgressOnly, "y");
@@ -824,10 +824,10 @@ testRun(void)
                     // {uncrustify_on}
                     "json - single stanza, valid backup, no priors, no archives in latest DB, backup/expire lock detected");
 
-                HRN_CFG_LOAD(cfgCmdInfo, argListSkipWalRange);
+                HRN_CFG_LOAD(cfgCmdInfo, argListNoWalRange);
                 // Only the database with id=3 is displayed in the archive section because it is the only one associated with a
                 // backup that includes WAL archive information.
-                // Other databases are omitted due to the absence of WAL archives or backups, and the --skip-wal-range option
+                // Other databases are omitted due to the absence of WAL archives or backups, and the --no-wal-range option
                 // prevents scanning for additional WAL files in the repository.
                 TEST_RESULT_STR_Z(
                     infoRender(),
@@ -950,7 +950,7 @@ testRun(void)
                         "}"
                     "]",
                     // {uncrustify_on}
-                    "json (skip wal range) - single stanza, valid backup, no priors, no archives in latest DB, backup/expire lock detected");
+                    "json (no wal range) - single stanza, valid backup, no priors, no archives in latest DB, backup/expire lock detected");
 
                 HRN_CFG_LOAD(cfgCmdInfo, argListProgressOnly);
                 TEST_RESULT_STR_Z(
@@ -999,10 +999,10 @@ testRun(void)
                     "text - single stanza, valid backup, no priors, no archives in latest DB, backup/expire lock detected");
 
                 // Display only the current database because no prior databases contain WAL archives or backups.
-                // The --skip-wal-range option prevents scanning for WAL files, so only databases explicitly linked to backups
+                // The --no-wal-range option prevents scanning for WAL files, so only databases explicitly linked to backups
                 // appear in the output.
                 // The full backup 20201116-154900F includes WAL start/stop information, making it the only visible archive.
-                HRN_CFG_LOAD(cfgCmdInfo, argListTextSkipWalRange);
+                HRN_CFG_LOAD(cfgCmdInfo, argListTextNoWalRange);
                 TEST_RESULT_STR_Z(
                     infoRender(),
                     "stanza: stanza1\n"
@@ -1023,7 +1023,7 @@ testRun(void)
                     "            wal start/stop: 000000030000000000000001 / 000000030000000000000001\n"
                     "            database size: 25.7MB, database backup size: 25.7MB\n"
                     "            repo1: backup set size: 3MB, backup size: 3KB\n",
-                    "text (skip wal range) - single stanza, valid backup, no priors, no archives in latest DB, backup/expire lock detected");
+                    "text (no wal range) - single stanza, valid backup, no priors, no archives in latest DB, backup/expire lock detected");
 
                 HRN_CFG_LOAD(cfgCmdInfo, argListTextProgressOnly);
                 TEST_RESULT_STR_Z(


### PR DESCRIPTION
Implement MVP of --wal-range option for info command to test suggested approach.
Do not merge this branch. Provide it for perf tests first.  

This new option controls whether begin/end WAL segment scanning is performed.
By default, WAL range scanning is enabled, but it can be disabled (--no-wal-range)
to reduce overhead.
