### PR TITLE
Fix replacing of filtered WAL record with no-op

### DIFF
--- a/src/common/walFilter/walFilter.c
+++ b/src/common/walFilter/walFilter.c
@@ -335,8 +335,9 @@ filterRecord(WalFilterState *const this)
     }
 
     this->record->xl_rmid = RM_XLOG_ID;
-    // Save 4 least significant bits which represent backup blocks flags.
-    this->record->xl_info = (uint8_t) (XLOG_NOOP | (this->record->xl_info & XLR_INFO_MASK));
+    this->record->xl_info = (uint8_t) XLOG_NOOP; // Clear backup blocks bits
+    // If the initial record has backup blocks, than treat them as rmgr-specific data
+    this->record->xl_len = this->record->xl_tot_len - (uint32) SizeOfXLogRecord;
     this->record->xl_crc = this->walInterface->xLogRecordChecksum(this->record, this->heapPageSize);
 }
 

--- a/src/common/walFilter/walFilter.c
+++ b/src/common/walFilter/walFilter.c
@@ -336,7 +336,7 @@ filterRecord(WalFilterState *const this)
 
     this->record->xl_rmid = RM_XLOG_ID;
     this->record->xl_info = (uint8_t) XLOG_NOOP; // Clear backup blocks bits
-    // If the initial record has backup blocks, than treat them as rmgr-specific data
+    // If the initial record has backup blocks, then treat them as rmgr-specific data
     this->record->xl_len = this->record->xl_tot_len - (uint32) SizeOfXLogRecord;
     this->record->xl_crc = this->walInterface->xLogRecordChecksum(this->record, this->heapPageSize);
 }

--- a/test/src/module/common/walFilterTest.c
+++ b/test/src/module/common/walFilterTest.c
@@ -1703,19 +1703,13 @@ testRun(void)
         }
         Buffer *expect_wal = bufNew(1024 * 1024);
         {
-            uint8_t info = XLOG_NOOP;
-            info |= XLR_BKP_BLOCK(0);
-            info |= XLR_BKP_BLOCK(1);
-            info |= XLR_BKP_BLOCK(2);
-            info |= XLR_BKP_BLOCK(3);
-
             uint32_t bodySize = sizeof(node1) + XLR_MAX_BKP_BLOCKS * (sizeof(BkpBlock) + DEFAULT_GDPB_PAGE_SIZE);
             char *body = memNew(bodySize);
             RelFileNode *node = (RelFileNode *) body;
             *node = node1;
             memset(body + sizeof(node1), 0, bodySize - sizeof(node1));
 
-            record = hrnGpdbCreateXRecordP(RM_XLOG_ID, info, bodySize, body, .xl_len = sizeof(node1));
+            record = hrnGpdbCreateXRecordP(RM_XLOG_ID, XLOG_NOOP, bodySize, body, .xl_len = bodySize);
             hrnGpdbWalInsertXRecordP(expect_wal, record, NO_FLAGS);
 
             record = hrnGpdbCreateXRecordP(0, XLOG_SWITCH, 0, NULL);


### PR DESCRIPTION
Fix replacing of filtered WAL record with no-op

GPDB does not expect backup blocks in records whose resource manager is XLOG, so
the https://github.com/arenadata/gpdb/blob/1b44caf6b58a8d60e4b0630a44d1c031cf739eae/src/backend/access/transam/xlog.c#L10439
assert was triggered in the case when a record with backup blocks was filtered
out.

If the initial record has backup blocks, clear their flags in the xl_info field
and increase xl_len to treat the backup blocks as a resource manager specific
data. The contents of resource manager specific data does not matter if the
record is no-op.

