### PR TITLE
ADBM-2169: Fix the processing of multi-page WAL records at the beginning and end of the WAL file

### DIFF
--- a/src/common/walFilter/walFilter.c
+++ b/src/common/walFilter/walFilter.c
@@ -128,7 +128,6 @@ getNextPage(WalFilterState *const this, const Buffer *const input)
 {
     if (this->inputOffset >= bufUsed(input))
     {
-        ASSERT(this->currentStep != noStep);
         this->inputOffset = 0;
         this->inputSame = false;
         return false;
@@ -178,7 +177,8 @@ readRecord(WalFilterState *const this, const Buffer *const input)
             goto stepReadBody;
     }
 
-    if (this->pageOffset == 0 || this->pageOffset == this->walPageSize)
+    ASSERT(this->pageOffset != 0);
+    if (this->pageOffset == this->walPageSize)
     {
         this->currentStep = stepBeginOfRecord;
 stepBeginOfRecord:
@@ -187,18 +187,8 @@ stepBeginOfRecord:
             return ReadRecordNeedBuffer;
         }
 
-        if (this->isBegin)
-        {
-            this->isBegin = false;
-            // There may be an unfinished record from the previous file at the beginning of the file. Just skip it.
-            // We should have handled it elsewhere.
-            if (this->currentPageHeader->xlp_info & XLP_FIRST_IS_CONTRECORD &&
-                !(this->currentPageHeader->xlp_info & XLP_FIRST_IS_OVERWRITE_CONTRECORD))
-            {
-                this->pageOffset += MAXALIGN(this->currentPageHeader->xlp_rem_len);
-            }
-        }
-        else if (this->currentPageHeader->xlp_info & XLP_FIRST_IS_CONTRECORD)
+        ASSERT(!this->isBegin);
+        if (this->currentPageHeader->xlp_info & XLP_FIRST_IS_CONTRECORD)
         {
             THROW_FMT(FormatError, "%s - should not be XLP_FIRST_IS_CONTRECORD", strZ(pgLsnToStr(this->recPtr)));
         }
@@ -464,13 +454,38 @@ readBeginOfRecord(WalFilterState *const this)
     }
 
     ioReadOpen(storageReadIo(storageRead));
-    this->isBegin = true;
     this->inputOffset = 0;
     this->pageOffset = 0;
 
     Buffer *const buffer = bufNew(this->walPageSize);
     size_t size = ioRead(storageReadIo(storageRead), buffer);
     bufUsedSet(buffer, size);
+
+    // There may be an unfinished record from the previous file at the beginning of the file. Just skip it.
+    while (true)
+    {
+#ifdef DEBUG
+        bool ret =
+#endif
+        getNextPage(this, buffer);
+        ASSERT(ret);
+        if (!(this->currentPageHeader->xlp_info & XLP_FIRST_IS_CONTRECORD) ||
+            this->currentPageHeader->xlp_info & XLP_FIRST_IS_OVERWRITE_CONTRECORD)
+        {
+            break;
+        }
+
+        if (this->currentPageHeader->xlp_rem_len <= this->walPageSize - this->pageOffset)
+        {
+            this->pageOffset += MAXALIGN(this->currentPageHeader->xlp_rem_len);
+            break;
+        }
+
+        bufUsedZero(buffer);
+        size = ioRead(storageReadIo(storageRead), buffer);
+        bufUsedSet(buffer, size);
+        this->inputOffset = 0;
+    }
 
     while (!ioReadEof(storageReadIo(storageRead)))
     {
@@ -599,18 +614,24 @@ walFilterProcess(THIS_VOID, const Buffer *const input, Buffer *const output)
             }
 
             this->inputOffset = 0;
-            getNextPage(this, input);
-            ASSERT(this->recPtr == this->currentPageHeader->xlp_pageaddr);
-            bufCatC(output, (const unsigned char *) this->currentPageHeader, 0, SizeOfXLogLongPHD);
-            this->recPtr += SizeOfXLogLongPHD;
+            do
+            {
+                if (!getNextPage(this, input))
+                {
+                    THROW_FMT(FormatError, "%s - record is too big", strZ(pgLsnToStr(this->recPtr)));
+                }
+                bufCatC(output, (const unsigned char *) this->currentPageHeader, 0, XLogPageHeaderSize(this->currentPageHeader));
+                ASSERT(this->recPtr == this->currentPageHeader->xlp_pageaddr);
+                this->recPtr += XLogPageHeaderSize(this->currentPageHeader);
 
-            lstClearFast(this->pageHeaders);
-
-            // The header that needs to be modified is in another file or not exists. Just copy it as is.
-            bufCatC(output, bufPtrConst(input), this->pageOffset, MAXALIGN(this->currentPageHeader->xlp_rem_len));
-
+                size_t toCopy = Min(MAXALIGN(this->currentPageHeader->xlp_rem_len), this->walPageSize - this->pageOffset);
+                ASSERT(!(this->currentPageHeader->xlp_info & XLP_FIRST_IS_OVERWRITE_CONTRECORD) || toCopy == 0);
+                bufCatC(output, (const unsigned char *) this->currentPageHeader, this->pageOffset, toCopy);
+                this->recPtr += toCopy;
+            }
+            while (this->currentPageHeader->xlp_rem_len > this->walPageSize - this->pageOffset);
             this->pageOffset += MAXALIGN(this->currentPageHeader->xlp_rem_len);
-            this->recPtr += MAXALIGN(this->currentPageHeader->xlp_rem_len);
+            lstClearFast(this->pageHeaders);
         }
     }
 

--- a/src/common/walFilter/walFilter.c
+++ b/src/common/walFilter/walFilter.c
@@ -358,6 +358,11 @@ writeRecord(WalFilterState *const this, Buffer *const output, const unsigned cha
         wrote += to_write;
         this->recPtr += to_write;
 
+        // Stop if we have reached the end of the segment file.
+        // This can happen if we have an incomplete record at the end of the file.
+        if (this->recPtr % this->segSize == 0)
+            return;
+
         // write header
         if (header_i < lstSize(this->pageHeaders))
         {
@@ -561,16 +566,13 @@ walFilterProcess(THIS_VOID, const Buffer *const input, Buffer *const output)
         // We have an incomplete record at the end
         if (this->currentStep != noStep)
         {
-            const size_t size_on_page = this->gotLen;
-
             // if xl_info and xl_rmid of the header is in current file then read end of record from next file if it exits
             if (this->gotLen >= offsetof(XLogRecord, xl_rmid) + SIZE_OF_STRUCT_MEMBER(XLogRecord, xl_rmid))
             {
                 getEndOfRecord(this);
                 filterRecord(this);
             }
-
-            bufCatC(output, (const unsigned char *) this->record, 0, size_on_page);
+            writeRecord(this, output, (const unsigned char *) this->record);
         }
         this->done = true;
         goto end;

--- a/test/src/common/harnessWal.c
+++ b/test/src/common/harnessWal.c
@@ -53,6 +53,8 @@ hrnGpdbWalInsertXRecord(
 
     if (param.walPageSize == 0)
         param.walPageSize = DEFAULT_GDPB_XLOG_PAGE_SIZE;
+    if (param.segSize == 0)
+        param.segSize = GPDB6_XLOG_SEG_SIZE;
 
     if (bufUsed(walBuffer) == 0)
     {
@@ -62,10 +64,10 @@ hrnGpdbWalInsertXRecord(
         longHeader.std.xlp_magic = param.magic;
         longHeader.std.xlp_info = XLP_LONG_HEADER;
         longHeader.std.xlp_tli = 1;
-        longHeader.std.xlp_pageaddr = param.segno * GPDB6_XLOG_SEG_SIZE;
+        longHeader.std.xlp_pageaddr = param.segno * param.segSize;
         longHeader.std.xlp_rem_len = param.beginOffset;
         longHeader.xlp_sysid = 10000000000000090400ULL;
-        longHeader.xlp_seg_size = GPDB6_XLOG_SEG_SIZE;
+        longHeader.xlp_seg_size = param.segSize;
         longHeader.xlp_xlog_blcksz = param.walPageSize;
 
         if (flags & OVERWRITE)
@@ -86,7 +88,7 @@ hrnGpdbWalInsertXRecord(
         XLogPageHeaderData header = {0};
         header.xlp_magic = param.magic;
         header.xlp_tli = 1;
-        header.xlp_pageaddr = param.segno * GPDB6_XLOG_SEG_SIZE + bufUsed(walBuffer);
+        header.xlp_pageaddr = param.segno * param.segSize + bufUsed(walBuffer);
         header.xlp_rem_len = 0;
 
         if (flags & COND_FLAG)
@@ -146,7 +148,7 @@ hrnGpdbWalInsertXRecord(
             header.xlp_magic = param.magic;
             header.xlp_info = !(flags & NO_COND_FLAG) ? XLP_FIRST_IS_CONTRECORD : 0;
             header.xlp_tli = 1;
-            header.xlp_pageaddr = param.segno * GPDB6_XLOG_SEG_SIZE + bufUsed(walBuffer);
+            header.xlp_pageaddr = param.segno * param.segSize + bufUsed(walBuffer);
 
             if (flags & ZERO_REM_LEN)
                 header.xlp_rem_len = 0;

--- a/test/src/common/harnessWal.c
+++ b/test/src/common/harnessWal.c
@@ -86,7 +86,7 @@ hrnGpdbWalInsertXRecord(
         XLogPageHeaderData header = {0};
         header.xlp_magic = param.magic;
         header.xlp_tli = 1;
-        header.xlp_pageaddr = bufUsed(walBuffer);
+        header.xlp_pageaddr = param.segno * GPDB6_XLOG_SEG_SIZE + bufUsed(walBuffer);
         header.xlp_rem_len = 0;
 
         if (flags & COND_FLAG)
@@ -131,7 +131,12 @@ hrnGpdbWalInsertXRecord(
 
             bufUsedInc(walBuffer, toWrite);
             if (flags & INCOMPLETE_RECORD)
-                return;
+            {
+                if (param.incompletePosition == 0)
+                    return;
+                else
+                    param.incompletePosition--;
+            }
             if (wrote == totalLen)
                 break;
 

--- a/test/src/common/harnessWal.h
+++ b/test/src/common/harnessWal.h
@@ -26,6 +26,7 @@ typedef struct InsertXRecordParam
     uint16_t magic;
     uint32_t beginOffset;
     uint64_t segno;
+    uint32_t segSize;
     PgPageSize walPageSize;
     uint32_t incompletePosition;
 } InsertXRecordParam;

--- a/test/src/common/harnessWal.h
+++ b/test/src/common/harnessWal.h
@@ -27,6 +27,7 @@ typedef struct InsertXRecordParam
     uint32_t beginOffset;
     uint64_t segno;
     PgPageSize walPageSize;
+    uint32_t incompletePosition;
 } InsertXRecordParam;
 
 typedef struct CreateXRecordParam

--- a/test/src/module/common/walFilterTest.c
+++ b/test/src/module/common/walFilterTest.c
@@ -242,6 +242,84 @@ testRun(void)
             STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000001-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd");
         MEM_CONTEXT_TEMP_END();
 
+        TEST_TITLE("long incomplete record in the beginning of prev file");
+        MEM_CONTEXT_TEMP_BEGIN();
+        filter = walFilterNew(pgControl, &archiveInfo);
+        {
+            Buffer *wal1 = bufNew(DEFAULT_GDPB_XLOG_PAGE_SIZE * 3);
+            record = hrnGpdbCreateXRecordP(RM_XLOG_ID, XLOG_NOOP, DEFAULT_GDPB_XLOG_PAGE_SIZE * 3, NULL);
+            hrnGpdbWalInsertXRecordP(wal1, record, NO_FLAGS, .beginOffset = DEFAULT_GDPB_XLOG_PAGE_SIZE * 2);
+
+            record = hrnGpdbCreateXRecordP(RM_XLOG_ID, XLOG_NOOP, DEFAULT_GDPB_XLOG_PAGE_SIZE * 2, NULL);
+            hrnGpdbWalInsertXRecordP(wal1, record, INCOMPLETE_RECORD);
+            fillLastPage(wal1, DEFAULT_GDPB_XLOG_PAGE_SIZE);
+
+            HRN_STORAGE_PUT(
+                storageRepoWrite(),
+                STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000001-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
+                wal1);
+        }
+        wal2 = bufNew(1024 * 1024);
+        record = hrnGpdbCreateXRecordP(RM_XLOG_ID, XLOG_NOOP, DEFAULT_GDPB_XLOG_PAGE_SIZE * 2, NULL);
+
+        // The size of the space occupied by the first record on the last page of the previous file.
+        size_t remLen =
+            (DEFAULT_GDPB_XLOG_PAGE_SIZE * 2 - DEFAULT_GDPB_XLOG_PAGE_SIZE - SizeOfXLogLongPHD) -
+            (DEFAULT_GDPB_XLOG_PAGE_SIZE - SizeOfXLogShortPHD);
+        hrnGpdbWalInsertXRecordP(
+            wal2,
+            record,
+            NO_FLAGS,
+            .segno = 2,
+            .beginOffset =
+                (uint32_t) (DEFAULT_GDPB_XLOG_PAGE_SIZE * 2 -
+                            (DEFAULT_GDPB_XLOG_PAGE_SIZE - SizeOfXLogShortPHD - SizeOfXLogRecord - remLen)));
+        record = hrnGpdbCreateXRecordP(0, XLOG_SWITCH, 0, NULL);
+        hrnGpdbWalInsertXRecordSimple(wal2, record);
+
+        fillLastPage(wal2, DEFAULT_GDPB_XLOG_PAGE_SIZE);
+        result = testFilter(filter, wal2, bufSize(wal2), bufSize(wal2));
+        TEST_RESULT_BOOL(bufEq(wal2, result), true, "WAL not the same");
+
+        HRN_STORAGE_REMOVE(
+            storageRepoWrite(),
+            STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000001-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd");
+        MEM_CONTEXT_TEMP_END();
+
+        TEST_TITLE("a long overridden incomplete record in the beginning of prev file");
+        MEM_CONTEXT_TEMP_BEGIN();
+        filter = walFilterNew(pgControl, &archiveInfo);
+        {
+            Buffer *wal1 = bufNew(DEFAULT_GDPB_XLOG_PAGE_SIZE * 3);
+            record = hrnGpdbCreateXRecordP(RM_XLOG_ID, XLOG_NOOP, DEFAULT_GDPB_XLOG_PAGE_SIZE * 3, NULL);
+            hrnGpdbWalInsertXRecordP(
+                wal1, record, INCOMPLETE_RECORD, .beginOffset = DEFAULT_GDPB_XLOG_PAGE_SIZE * 2, .incompletePosition = 1);
+
+            record = hrnGpdbCreateXRecordP(RM_XLOG_ID, XLOG_NOOP, DEFAULT_GDPB_XLOG_PAGE_SIZE * 2, NULL);
+            hrnGpdbWalInsertXRecordP(wal1, record, INCOMPLETE_RECORD | OVERWRITE);
+            fillLastPage(wal1, DEFAULT_GDPB_XLOG_PAGE_SIZE);
+
+            HRN_STORAGE_PUT(
+                storageRepoWrite(),
+                STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000001-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
+                wal1);
+        }
+        wal2 = bufNew(1024 * 1024);
+        record = hrnGpdbCreateXRecordP(RM_XLOG_ID, XLOG_NOOP, DEFAULT_GDPB_XLOG_PAGE_SIZE * 2, NULL);
+        hrnGpdbWalInsertXRecordP(
+            wal2, record, NO_FLAGS, .segno = 2, .beginOffset = DEFAULT_GDPB_XLOG_PAGE_SIZE - SizeOfXLogShortPHD - SizeOfXLogRecord);
+        record = hrnGpdbCreateXRecordP(0, XLOG_SWITCH, 0, NULL);
+        hrnGpdbWalInsertXRecordSimple(wal2, record);
+
+        fillLastPage(wal2, DEFAULT_GDPB_XLOG_PAGE_SIZE);
+        result = testFilter(filter, wal2, bufSize(wal2), bufSize(wal2));
+        TEST_RESULT_BOOL(bufEq(wal2, result), true, "WAL not the same");
+
+        HRN_STORAGE_REMOVE(
+            storageRepoWrite(),
+            STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000001-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd");
+        MEM_CONTEXT_TEMP_END();
+
         TEST_TITLE("override record in the beginning of prev file");
         MEM_CONTEXT_TEMP_BEGIN();
         filter = walFilterNew(pgControl, &archiveInfo);
@@ -473,6 +551,112 @@ testRun(void)
         fillLastPage(wal2, DEFAULT_GDPB_XLOG_PAGE_SIZE);
         result = testFilter(filter, wal2, DEFAULT_GDPB_XLOG_PAGE_SIZE, DEFAULT_GDPB_XLOG_PAGE_SIZE);
         TEST_RESULT_BOOL(bufEq(wal2, result), true, "WAL not the same");
+
+        HRN_STORAGE_REMOVE(
+            storageRepoWrite(),
+            STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000001-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd");
+        MEM_CONTEXT_TEMP_END();
+
+        TEST_TITLE("long record at the end of the previous file");
+        MEM_CONTEXT_TEMP_BEGIN();
+        filter = walFilterNew(pgControl, &archiveInfo);
+        {
+            Buffer *wal1 = bufNew(DEFAULT_GDPB_XLOG_PAGE_SIZE);
+
+            record = hrnGpdbCreateXRecordP(RM_XLOG_ID, XLOG_NOOP, DEFAULT_GDPB_XLOG_PAGE_SIZE / 2, NULL);
+            hrnGpdbWalInsertXRecordSimple(wal1, record);
+
+            record = hrnGpdbCreateXRecordP(RM_XLOG_ID, XLOG_NOOP, DEFAULT_GDPB_XLOG_PAGE_SIZE * 3, NULL);
+            hrnGpdbWalInsertXRecordP(wal1, record, INCOMPLETE_RECORD);
+
+            HRN_STORAGE_PUT(
+                storageRepoWrite(),
+                STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000001-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
+                wal1);
+        }
+
+        wal2 = bufNew(1024 * 1024);
+        record = hrnGpdbCreateXRecordP(RM_XLOG_ID, XLOG_NOOP, DEFAULT_GDPB_XLOG_PAGE_SIZE * 3, NULL);
+        hrnGpdbWalInsertXRecordP(wal2, record, 0, .segno = 2, .beginOffset = (DEFAULT_GDPB_XLOG_PAGE_SIZE * 3 + SizeOfXLogRecord) - DEFAULT_GDPB_XLOG_PAGE_SIZE / 2 - SizeOfXLogLongPHD - SizeOfXLogRecord);
+        record = hrnGpdbCreateXRecordP(RM_XLOG_ID, XLOG_NOOP, DEFAULT_GDPB_XLOG_PAGE_SIZE * 2, NULL);
+        hrnGpdbWalInsertXRecordSimple(wal2, record);
+        record = hrnGpdbCreateXRecordP(0, XLOG_SWITCH, 0, NULL);
+        hrnGpdbWalInsertXRecordSimple(wal2, record);
+
+        fillLastPage(wal2, DEFAULT_GDPB_XLOG_PAGE_SIZE);
+        result = testFilter(filter, wal2, 1024 * 1024, 1024 * 1024);
+        TEST_RESULT_BOOL(bufEq(wal2, result), true, "WAL not the same");
+
+        HRN_STORAGE_REMOVE(
+            storageRepoWrite(),
+            STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000001-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd");
+        MEM_CONTEXT_TEMP_END();
+
+        TEST_TITLE("long incomplete record at the end of the previous file");
+        MEM_CONTEXT_TEMP_BEGIN();
+        filter = walFilterNew(pgControl, &archiveInfo);
+        {
+            Buffer *wal1 = bufNew(DEFAULT_GDPB_XLOG_PAGE_SIZE);
+
+            record = hrnGpdbCreateXRecordP(RM_XLOG_ID, XLOG_NOOP, DEFAULT_GDPB_XLOG_PAGE_SIZE / 2, NULL);
+            hrnGpdbWalInsertXRecordSimple(wal1, record);
+
+            record = hrnGpdbCreateXRecordP(RM_XLOG_ID, XLOG_NOOP, DEFAULT_GDPB_XLOG_PAGE_SIZE * 3, NULL);
+            hrnGpdbWalInsertXRecordP(wal1, record, INCOMPLETE_RECORD);
+
+            HRN_STORAGE_PUT(
+                storageRepoWrite(),
+                STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000001-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
+                wal1);
+        }
+
+        wal2 = bufNew(1024 * 1024);
+        record = hrnGpdbCreateXRecordP(RM_XLOG_ID, XLOG_NOOP, DEFAULT_GDPB_XLOG_PAGE_SIZE * 3, NULL);
+        hrnGpdbWalInsertXRecordP(
+            wal2, record, INCOMPLETE_RECORD, .segno = 2,
+            .beginOffset = (DEFAULT_GDPB_XLOG_PAGE_SIZE * 3 + SizeOfXLogRecord) - DEFAULT_GDPB_XLOG_PAGE_SIZE / 2 - SizeOfXLogLongPHD - SizeOfXLogRecord);
+        record = hrnGpdbCreateXRecordP(RM_XLOG_ID, XLOG_NOOP, DEFAULT_GDPB_XLOG_PAGE_SIZE * 2, NULL);
+        hrnGpdbWalInsertXRecordP(wal2, record, OVERWRITE, .segno = 2);
+        record = hrnGpdbCreateXRecordP(0, XLOG_SWITCH, 0, NULL);
+        hrnGpdbWalInsertXRecordSimple(wal2, record);
+
+        fillLastPage(wal2, DEFAULT_GDPB_XLOG_PAGE_SIZE);
+        result = testFilter(filter, wal2, 1024 * 1024, 1024 * 1024);
+        TEST_RESULT_BOOL(bufEq(wal2, result), true, "WAL not the same");
+
+        HRN_STORAGE_REMOVE(
+            storageRepoWrite(),
+            STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000001-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd");
+        MEM_CONTEXT_TEMP_END();
+
+        TEST_TITLE("long record at the end of the previous file - record is too big");
+        MEM_CONTEXT_TEMP_BEGIN();
+        filter = walFilterNew(pgControl, &archiveInfo);
+        {
+            Buffer *wal1 = bufNew(DEFAULT_GDPB_XLOG_PAGE_SIZE);
+
+            record = hrnGpdbCreateXRecordP(RM_XLOG_ID, XLOG_NOOP, DEFAULT_GDPB_XLOG_PAGE_SIZE / 2, NULL);
+            hrnGpdbWalInsertXRecordSimple(wal1, record);
+
+            record = hrnGpdbCreateXRecordP(RM_XLOG_ID, XLOG_NOOP, DEFAULT_GDPB_XLOG_PAGE_SIZE * 3, NULL);
+            hrnGpdbWalInsertXRecordP(wal1, record, INCOMPLETE_RECORD);
+
+            HRN_STORAGE_PUT(
+                storageRepoWrite(),
+                STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000001-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
+                wal1);
+        }
+
+        wal2 = bufNew(1024 * 1024);
+        record = hrnGpdbCreateXRecordP(RM_XLOG_ID, XLOG_NOOP, DEFAULT_GDPB_XLOG_PAGE_SIZE * 3, NULL);
+        hrnGpdbWalInsertXRecordP(wal2, record, 0, .segno = 2, .beginOffset = (DEFAULT_GDPB_XLOG_PAGE_SIZE * 3 + SizeOfXLogRecord) - DEFAULT_GDPB_XLOG_PAGE_SIZE / 2 - SizeOfXLogLongPHD - SizeOfXLogRecord);
+        record = hrnGpdbCreateXRecordP(RM_XLOG_ID, XLOG_NOOP, DEFAULT_GDPB_XLOG_PAGE_SIZE * 2, NULL);
+        hrnGpdbWalInsertXRecordSimple(wal2, record);
+        record = hrnGpdbCreateXRecordP(0, XLOG_SWITCH, 0, NULL);
+        hrnGpdbWalInsertXRecordSimple(wal2, record);
+
+        fillLastPage(wal2, DEFAULT_GDPB_XLOG_PAGE_SIZE);
+        TEST_ERROR(testFilter(filter, wal2, DEFAULT_GDPB_XLOG_PAGE_SIZE, 1024 * 1024), FormatError, "0/8008000 - record is too big");
 
         HRN_STORAGE_REMOVE(
             storageRepoWrite(),
@@ -1026,6 +1210,27 @@ testRun(void)
             size_t to_write = DEFAULT_GDPB_XLOG_PAGE_SIZE * 2 - bufUsed(wal);
             memset(bufRemainsPtr(wal), 0, to_write);
             bufUsedInc(wal, to_write);
+        }
+        result = testFilter(filter, wal, bufSize(wal), bufSize(wal));
+        TEST_RESULT_BOOL(bufEq(wal, result), true, "WAL not the same");
+        MEM_CONTEXT_TEMP_END();
+
+        TEST_TITLE("override record in long body");
+        MEM_CONTEXT_TEMP_BEGIN();
+        filter = walFilterNew(pgControl, NULL);
+        {
+            wal = bufNew(DEFAULT_GDPB_XLOG_PAGE_SIZE * 3);
+
+            record = hrnGpdbCreateXRecordP(RM_XLOG_ID, XLOG_NOOP, DEFAULT_GDPB_XLOG_PAGE_SIZE - 3000, NULL);
+            hrnGpdbWalInsertXRecordSimple(wal, record);
+            record = hrnGpdbCreateXRecordP(RM_XLOG_ID, XLOG_NOOP, DEFAULT_GDPB_XLOG_PAGE_SIZE * 2, NULL);
+            hrnGpdbWalInsertXRecordP(wal, record, INCOMPLETE_RECORD, .incompletePosition = 1);
+            record = hrnGpdbCreateXRecordP(RM_XLOG_ID, XLOG_NOOP, 100, NULL);
+            hrnGpdbWalInsertXRecordP(wal, record, OVERWRITE);
+            record = hrnGpdbCreateXRecordP(0, XLOG_SWITCH, 0, NULL);
+            hrnGpdbWalInsertXRecordSimple(wal, record);
+
+            fillLastPage(wal, DEFAULT_GDPB_XLOG_PAGE_SIZE);
         }
         result = testFilter(filter, wal, bufSize(wal), bufSize(wal));
         TEST_RESULT_BOOL(bufEq(wal, result), true, "WAL not the same");

--- a/test/src/module/common/walFilterTest.c
+++ b/test/src/module/common/walFilterTest.c
@@ -767,7 +767,9 @@ testRun(void)
 
         TEST_TITLE("simple read end from next file");
         MEM_CONTEXT_TEMP_BEGIN();
-        filter = walFilterNew(pgControl, &archiveInfo);
+        PgControl testPgControl = pgControl;
+        testPgControl.walSegmentSize = DEFAULT_GDPB_XLOG_PAGE_SIZE;
+        filter = walFilterNew(testPgControl, &archiveInfo);
         {
             Buffer *wal1 = bufNew(DEFAULT_GDPB_XLOG_PAGE_SIZE);
 
@@ -817,12 +819,15 @@ testRun(void)
 
         TEST_TITLE("multiply WAL files");
         MEM_CONTEXT_TEMP_BEGIN();
-        filter = walFilterNew(pgControl, &archiveInfo);
+
+        PgControl testPgControl = pgControl;
+        testPgControl.walSegmentSize = DEFAULT_GDPB_XLOG_PAGE_SIZE;
+        filter = walFilterNew(testPgControl, &archiveInfo);
         {
             Buffer *wal1 = bufNew(DEFAULT_GDPB_XLOG_PAGE_SIZE);
 
             record = hrnGpdbCreateXRecordP(RM_XLOG_ID, XLOG_NOOP, 100, NULL);
-            hrnGpdbWalInsertXRecordP(wal1, record, 0, .beginOffset = 100);
+            hrnGpdbWalInsertXRecordP(wal1, record, 0, .beginOffset = 100, .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE);
             fillLastPage(wal1, DEFAULT_GDPB_XLOG_PAGE_SIZE);
 
             Buffer *zeros = bufNew(DEFAULT_GDPB_XLOG_PAGE_SIZE);
@@ -846,9 +851,9 @@ testRun(void)
         // Subtract SizeOfXLogRecord twice to leave exactly space at the end of the page for the header of the next record.
         record = hrnGpdbCreateXRecordP(
             RM_XLOG_ID, XLOG_NOOP, DEFAULT_GDPB_XLOG_PAGE_SIZE - SizeOfXLogLongPHD - SizeOfXLogRecord - SizeOfXLogRecord, NULL);
-        hrnGpdbWalInsertXRecordP(wal2, record, NO_FLAGS, .segno = 1);
+        hrnGpdbWalInsertXRecordP(wal2, record, NO_FLAGS, .segno = 1, .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE);
         record = hrnGpdbCreateXRecordP(RM_XLOG_ID, XLOG_NOOP, 100, NULL);
-        hrnGpdbWalInsertXRecordP(wal2, record, INCOMPLETE_RECORD, .segno = 1);
+        hrnGpdbWalInsertXRecordP(wal2, record, INCOMPLETE_RECORD, .segno = 1, .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE);
 
         fillLastPage(wal2, DEFAULT_GDPB_XLOG_PAGE_SIZE);
         result = testFilter(filter, wal2, bufSize(wal2), bufSize(wal2));
@@ -898,13 +903,15 @@ testRun(void)
 
         TEST_TITLE("read more then one page from next file");
         MEM_CONTEXT_TEMP_BEGIN();
-        filter = walFilterNew(pgControl, &archiveInfo);
+        PgControl testPgControl = pgControl;
+        testPgControl.walSegmentSize = DEFAULT_GDPB_XLOG_PAGE_SIZE * 3;
+        filter = walFilterNew(testPgControl, &archiveInfo);
         {
             Buffer *wal1 = bufNew(DEFAULT_GDPB_XLOG_PAGE_SIZE * 3);
 
             record = hrnGpdbCreateXRecordP(
                 RM_XLOG_ID, XLOG_NOOP, DEFAULT_GDPB_XLOG_PAGE_SIZE * 2 - SizeOfXLogRecord, NULL);
-            hrnGpdbWalInsertXRecordP(wal1, record, 0, .beginOffset = DEFAULT_GDPB_XLOG_PAGE_SIZE * 2 - SizeOfXLogRecord);
+            hrnGpdbWalInsertXRecordP(wal1, record, 0, .beginOffset = DEFAULT_GDPB_XLOG_PAGE_SIZE * 2 - SizeOfXLogRecord, .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE * 3);
             fillLastPage(wal1, DEFAULT_GDPB_XLOG_PAGE_SIZE);
 
             HRN_STORAGE_PUT(
@@ -913,13 +920,57 @@ testRun(void)
                 wal1);
         }
 
-        wal2 = bufNew(1024 * 1024);
+        wal2 = bufNew(DEFAULT_GDPB_XLOG_PAGE_SIZE * 3);
         // Subtract SizeOfXLogRecord twice to leave exactly space at the end of the page for the header of the next record.
         record = hrnGpdbCreateXRecordP(
-            RM_XLOG_ID, XLOG_NOOP, DEFAULT_GDPB_XLOG_PAGE_SIZE - SizeOfXLogLongPHD - SizeOfXLogRecord - SizeOfXLogRecord, NULL);
-        hrnGpdbWalInsertXRecordSimple(wal2, record);
+            RM_XLOG_ID, XLOG_NOOP,
+            DEFAULT_GDPB_XLOG_PAGE_SIZE * 3 - SizeOfXLogLongPHD - SizeOfXLogRecord - SizeOfXLogShortPHD - SizeOfXLogShortPHD - SizeOfXLogRecord, NULL);
+        hrnGpdbWalInsertXRecordP(wal2, record, NO_FLAGS, .segno = 1, .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE * 3);
         record = hrnGpdbCreateXRecordP(RM_XLOG_ID, XLOG_NOOP, (DEFAULT_GDPB_XLOG_PAGE_SIZE * 2) - SizeOfXLogRecord, NULL);
-        hrnGpdbWalInsertXRecordP(wal2, record, INCOMPLETE_RECORD, .segno = 1);
+        hrnGpdbWalInsertXRecordP(wal2, record, INCOMPLETE_RECORD, .segno = 1, .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE * 3);
+
+        fillLastPage(wal2, DEFAULT_GDPB_XLOG_PAGE_SIZE);
+        result = testFilter(filter, wal2, bufSize(wal2), bufSize(wal2));
+        TEST_RESULT_BOOL(bufEq(wal2, result), true, "WAL not the same");
+
+        HRN_STORAGE_REMOVE(
+            storageRepoWrite(),
+            STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000002-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd");
+        MEM_CONTEXT_TEMP_END();
+
+        TEST_TITLE("a long record at the end of the file");
+        MEM_CONTEXT_TEMP_BEGIN();
+        PgControl testPgControl = pgControl;
+        testPgControl.walSegmentSize = DEFAULT_GDPB_XLOG_PAGE_SIZE * 3;
+        filter = walFilterNew(testPgControl, &archiveInfo);
+        {
+            Buffer *wal1 = bufNew(DEFAULT_GDPB_XLOG_PAGE_SIZE * 3);
+
+            record = hrnGpdbCreateXRecordP(
+                RM_XLOG_ID, XLOG_NOOP, DEFAULT_GDPB_XLOG_PAGE_SIZE * 4, NULL);
+            // LPH - long page header (40 bytes)
+            // SPH - short page header (24 bytes)
+            // RH  - record header (32 bytes)
+            // B   - record body (var len)
+            // layout of the first file:
+            // 40  32 32696 |24  72 32 32640 |24 32744
+            // LPH RH   B   |SPH B  RH   B   |PH   B
+            // DEFAULT_GDPB_XLOG_PAGE_SIZE * 4 - 32640 - 32744 = 65688
+            hrnGpdbWalInsertXRecordP(wal1, record, 0, .beginOffset = 65688, .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE * 3);
+            fillLastPage(wal1, DEFAULT_GDPB_XLOG_PAGE_SIZE);
+
+            HRN_STORAGE_PUT(
+                storageRepoWrite(),
+                STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000002-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
+                wal1);
+        }
+
+        wal2 = bufNew(DEFAULT_GDPB_XLOG_PAGE_SIZE * 3);
+
+        record = hrnGpdbCreateXRecordP(RM_XLOG_ID, XLOG_NOOP, DEFAULT_GDPB_XLOG_PAGE_SIZE, NULL);
+        hrnGpdbWalInsertXRecordP(wal2, record, NO_FLAGS, .segno = 1, .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE * 3);
+        record = hrnGpdbCreateXRecordP(RM_XLOG_ID, XLOG_NOOP, DEFAULT_GDPB_XLOG_PAGE_SIZE * 4, NULL);
+        hrnGpdbWalInsertXRecordP(wal2, record, INCOMPLETE_RECORD, .segno = 1, .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE * 3, .incompletePosition = 1);
 
         fillLastPage(wal2, DEFAULT_GDPB_XLOG_PAGE_SIZE);
         result = testFilter(filter, wal2, bufSize(wal2), bufSize(wal2));
@@ -1020,12 +1071,14 @@ testRun(void)
         archiveInfo.file = STRDEF(
             STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000001-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd.gz");
 
-        filter = walFilterNew(pgControl, &archiveInfo);
+        PgControl testPgControl = pgControl;
+        testPgControl.walSegmentSize = DEFAULT_GDPB_XLOG_PAGE_SIZE;
+        filter = walFilterNew(testPgControl, &archiveInfo);
         {
             Buffer *wal1 = bufNew(DEFAULT_GDPB_XLOG_PAGE_SIZE);
 
             record = hrnGpdbCreateXRecordP(RM_XLOG_ID, XLOG_NOOP, 100, NULL);
-            hrnGpdbWalInsertXRecordP(wal1, record, 0, .beginOffset = 100);
+            hrnGpdbWalInsertXRecordP(wal1, record, 0, .beginOffset = 100, .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE);
             fillLastPage(wal1, DEFAULT_GDPB_XLOG_PAGE_SIZE);
 
             HRN_STORAGE_PUT(
@@ -1034,13 +1087,13 @@ testRun(void)
                 wal1, .compressType = compressTypeGz, .cipherType = cipherTypeAes256Cbc, .cipherPass = TEST_CIPHER_PASS_ARCHIVE);
         }
 
-        wal2 = bufNew(1024 * 1024);
+        wal2 = bufNew(DEFAULT_GDPB_XLOG_PAGE_SIZE);
         // Subtract SizeOfXLogRecord twice to leave exactly space at the end of the page for the header of the next record.
         record = hrnGpdbCreateXRecordP(
             RM_XLOG_ID, XLOG_NOOP, DEFAULT_GDPB_XLOG_PAGE_SIZE - SizeOfXLogLongPHD - SizeOfXLogRecord - SizeOfXLogRecord, NULL);
-        hrnGpdbWalInsertXRecordSimple(wal2, record);
+        hrnGpdbWalInsertXRecordP(wal2, record, NO_FLAGS, .segno = 0, .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE);
         record = hrnGpdbCreateXRecordP(RM_XLOG_ID, XLOG_NOOP, 100, NULL);
-        hrnGpdbWalInsertXRecordP(wal2, record, INCOMPLETE_RECORD, .segno = 1);
+        hrnGpdbWalInsertXRecordP(wal2, record, INCOMPLETE_RECORD, .segno = 0, .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE);
 
         fillLastPage(wal2, DEFAULT_GDPB_XLOG_PAGE_SIZE);
         result = testFilter(filter, wal2, bufSize(wal2), bufSize(wal2));


### PR DESCRIPTION
Fix the processing of multi-page WAL records at the beginning and end of the WAL file (#70)

WAL records can be split into 2 files. If such a record is located at the
beginning of the current file, then we need to first read the beginning of this
record from the previous file. Depending on how much of the record is in the
previous file, we either filter the records or write what is in the current file
as it is. The second case also occurs if the previous file does not exist in the
archive. Previously, the xlp_rem_len field was used to determine how much data
needs to be copied as is from the beginning of the file. The problem is that
this field does not take into account the size of the headers that are inside
the record if its size is greater than one page. Because of this, the record was
not fully copied, which led to further errors in reading the WAL. The issue
could also occur when reading the previous file, where there may also be an
unfinished record at the beginning that needs to be skipped.
A similar situation may occur when writing the last record in a segment file.
The part of the record that we read was copied to the end of the file, without
taking into account that more than one page could have been read. Therefore, in
addition to the record itself, it is also necessary to write the headers.

Fix reading at the beginning of the file by adding a loop to the copying process
in which we copy data sequentially from each of the pages, taking into account
their headers.
Fix the writing at the end of the file by replacing simply copying with using
the WriteRecord function, which writes taking into account the headers. Also add
a check for the end of the segment file to this function.
Also add various tests for multi-page records when reading from a previous file.