### PR TITLE
Update runner versions on Github actions.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       # Let all the jobs run to completion even if one fails
@@ -160,8 +160,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Packages
-        run: sudo apt-get install -y --no-install-recommends libyaml-dev libbz2-dev
-
+        run: sudo apt-get install -y --no-install-recommends libyaml-dev libbz2-dev meson
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
         with:


### PR DESCRIPTION
Ubuntu 20.04 will be EOL soon so update all actions that are using it. Update other actions as far as possible without making too many changes.

(cherry picked from commit 6244f02bb3f44f985df5562a90400b3e7c9b9163)