### PR TITLE
ADBM-2191: Remove PostgreSQL 12 from F41 and RHEL8 containers

### DIFF
--- a/doc/resource/exe.cache
+++ b/doc/resource/exe.cache
@@ -334,7 +334,6 @@
                   "id" : "sftp",
                   "image" : "pgbackrest/doc:debian",
                   "name" : "sftp-server",
-                  "option" : "-m 512m -v /sys/fs/cgroup:/sys/fs/cgroup:rw -v /tmp/$(mktemp -d):/run",
                   "os" : "debian",
                   "update-hosts" : true
                },
@@ -348,7 +347,6 @@
                   "id" : "build",
                   "image" : "pgbackrest/doc:debian",
                   "name" : "build",
-                  "option" : "-v /sys/fs/cgroup:/sys/fs/cgroup:rw -v /tmp/$(mktemp -d):/run",
                   "os" : "debian",
                   "update-hosts" : true
                },
@@ -455,7 +453,7 @@
                   "id" : "pg1",
                   "image" : "pgbackrest/doc:debian",
                   "name" : "pg-primary",
-                  "option" : "-m 512m -v /sys/fs/cgroup:/sys/fs/cgroup:rw -v /tmp/$(mktemp -d):/run",
+                  "option" : "-m 512m",
                   "os" : "debian",
                   "update-hosts" : true
                },
@@ -645,8 +643,8 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo -u postgres /usr/lib/postgresql/15/bin/initdb \\",
-                     "    -D /var/lib/postgresql/15/demo -k -A peer"
+                     "sudo -u postgres /usr/lib/postgresql/16/bin/initdb \\",
+                     "    -D /var/lib/postgresql/16/demo -k -A peer"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -659,7 +657,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo pg_createcluster 15 demo"
+                     "sudo pg_createcluster 16 demo"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -669,9 +667,9 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "Configuring already existing cluster (configuration: /etc/postgresql/15/demo, data: /var/lib/postgresql/15/demo, owner: 102:103)",
+                     "Configuring already existing cluster (configuration: /etc/postgresql/16/demo, data: /var/lib/postgresql/16/demo, owner: 102:103)",
                      "Ver Cluster Port Status Owner    Data directory              Log file",
-                     "15  demo    5432 down   postgres /var/lib/postgresql/15/demo /var/log/postgresql/postgresql-15-demo.log"
+                     "16  demo    5432 down   postgres /var/lib/postgresql/16/demo /var/log/postgresql/postgresql-16-demo.log"
                   ]
                }
             },
@@ -679,7 +677,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "cat /root/postgresql.common.conf >> /etc/postgresql/15/demo/postgresql.conf"
+                     "cat /root/postgresql.common.conf >> /etc/postgresql/16/demo/postgresql.conf"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -695,7 +693,7 @@
                   "option" : {
                      "demo" : {
                         "pg1-path" : {
-                           "value" : "/var/lib/postgresql/15/demo"
+                           "value" : "/var/lib/postgresql/16/demo"
                         }
                      },
                      "global" : {
@@ -712,7 +710,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/postgresql/15/demo"
+                     "pg1-path=/var/lib/postgresql/16/demo"
                   ]
                }
             },
@@ -806,7 +804,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/postgresql/15/demo",
+                     "pg1-path=/var/lib/postgresql/16/demo",
                      "",
                      "[global]",
                      "repo1-path=/var/lib/pgbackrest"
@@ -815,7 +813,7 @@
             },
             {
                "key" : {
-                  "file" : "/etc/postgresql/15/demo/postgresql.conf",
+                  "file" : "/etc/postgresql/16/demo/postgresql.conf",
                   "host" : "pg-primary",
                   "option" : {
                      "archive_command" : {
@@ -846,7 +844,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo pg_ctlcluster 15 demo restart"
+                     "sudo pg_ctlcluster 16 demo restart"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -909,7 +907,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/postgresql/15/demo",
+                     "pg1-path=/var/lib/postgresql/16/demo",
                      "",
                      "[global]",
                      "repo1-path=/var/lib/pgbackrest",
@@ -935,7 +933,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/postgresql/15/demo",
+                     "pg1-path=/var/lib/postgresql/16/demo",
                      "",
                      "[global]",
                      "repo1-path=/var/lib/pgbackrest",
@@ -965,7 +963,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/postgresql/15/demo",
+                     "pg1-path=/var/lib/postgresql/16/demo",
                      "",
                      "[global]",
                      "repo1-cipher-pass=zWaf6XtpjIVZC5444yXB+cgFDFl7MxGlgkZSaoPvTGirhPygu4jOKOXf9LO4vjfO",
@@ -999,7 +997,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: stanza-create command begin 2.52: --exec-id=385-b7c3d288 --log-level-console=info --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/postgresql/15/demo --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --stanza=demo",
+                     "P00   INFO: stanza-create command begin 2.52: --exec-id=385-b7c3d288 --log-level-console=info --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/postgresql/16/demo --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --stanza=demo",
                      "P00   INFO: stanza-create for stanza 'demo' on repo1",
                      "P00   INFO: stanza-create command end: completed successfully"
                   ]
@@ -1026,7 +1024,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: check command begin 2.52: --exec-id=393-258e8875 --log-level-console=info --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/postgresql/15/demo --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --stanza=demo",
+                     "P00   INFO: check command begin 2.52: --exec-id=393-258e8875 --log-level-console=info --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/postgresql/16/demo --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --stanza=demo",
                      "P00   INFO: check repo1 configuration (primary)",
                      "P00   INFO: check repo1 archive for WAL (primary)",
                      "P00   INFO: WAL segment 000000010000000000000001 successfully archived to '/var/lib/pgbackrest/archive/demo/15-1/0000000100000000/000000010000000000000001-ae7454844ef09dd231cac733dc1131a0d748fdba.gz' on repo1",
@@ -1050,7 +1048,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/postgresql/15/demo",
+                     "pg1-path=/var/lib/postgresql/16/demo",
                      "",
                      "[global]",
                      "repo1-cipher-pass=zWaf6XtpjIVZC5444yXB+cgFDFl7MxGlgkZSaoPvTGirhPygu4jOKOXf9LO4vjfO",
@@ -1086,7 +1084,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: backup command begin 2.52: --exec-id=418-d42a947d --log-level-console=info --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/postgresql/15/demo --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo1-retention-full=2 --stanza=demo --start-fast",
+                     "P00   INFO: backup command begin 2.52: --exec-id=418-d42a947d --log-level-console=info --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/postgresql/16/demo --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo1-retention-full=2 --stanza=demo --start-fast",
                      "P00   WARN: no prior backup exists, incr backup has been changed to full",
                      "P00   INFO: execute non-exclusive backup start: backup begins after the requested immediate checkpoint completes",
                      "P00   INFO: backup start archive = 000000010000000000000002, lsn = 0/2000028",
@@ -1174,7 +1172,7 @@
                      "    cipher: aes-256-cbc",
                      "",
                      "    db (current)",
-                     "        wal archive min/max (15): 000000010000000000000001/000000010000000000000005",
+                     "        wal archive min/max (16): 000000010000000000000001/000000010000000000000005",
                      "",
                      "        full backup: 20240527-001151F",
                      "            timestamp start/stop: 2024-05-27 00:11:51+00 / 2024-05-27 00:11:54+00",
@@ -1195,7 +1193,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo pg_ctlcluster 15 demo stop"
+                     "sudo pg_ctlcluster 16 demo stop"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -1208,7 +1206,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo -u postgres rm /var/lib/postgresql/15/demo/global/pg_control"
+                     "sudo -u postgres rm /var/lib/postgresql/16/demo/global/pg_control"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -1221,7 +1219,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo pg_ctlcluster 15 demo start"
+                     "sudo pg_ctlcluster 16 demo start"
                   ],
                   "err-expect" : "1",
                   "highlight" : {
@@ -1239,10 +1237,10 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "Error: /usr/lib/postgresql/15/bin/pg_ctl /usr/lib/postgresql/15/bin/pg_ctl start -D /var/lib/postgresql/15/demo -l /var/log/postgresql/postgresql-15-demo.log -s -o  -c config_file=\"/etc/postgresql/15/demo/postgresql.conf\"  exited with status 1: ",
+                     "Error: /usr/lib/postgresql/16/bin/pg_ctl /usr/lib/postgresql/16/bin/pg_ctl start -D /var/lib/postgresql/16/demo -l /var/log/postgresql/postgresql-16-demo.log -s -o  -c config_file=\"/etc/postgresql/16/demo/postgresql.conf\"  exited with status 1: ",
                      "postgres: could not find the database system",
-                     "Expected to find it in the directory \"/var/lib/postgresql/15/demo\",",
-                     "but could not open file \"/var/lib/postgresql/15/demo/global/pg_control\": No such file or directory",
+                     "Expected to find it in the directory \"/var/lib/postgresql/16/demo\",",
+                     "but could not open file \"/var/lib/postgresql/16/demo/global/pg_control\": No such file or directory",
                      "Examine the log output."
                   ]
                }
@@ -1251,7 +1249,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo -u postgres find /var/lib/postgresql/15/demo -mindepth 1 -delete"
+                     "sudo -u postgres find /var/lib/postgresql/16/demo -mindepth 1 -delete"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -1277,7 +1275,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo pg_ctlcluster 15 demo start"
+                     "sudo pg_ctlcluster 16 demo start"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -1513,7 +1511,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/postgresql/15/demo",
+                     "pg1-path=/var/lib/postgresql/16/demo",
                      "",
                      "[global]",
                      "repo1-bundle=y",
@@ -1575,7 +1573,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/postgresql/15/demo",
+                     "pg1-path=/var/lib/postgresql/16/demo",
                      "",
                      "[global]",
                      "repo1-block=y",
@@ -1649,7 +1647,7 @@
                      "    cipher: aes-256-cbc",
                      "",
                      "    db (current)",
-                     "        wal archive min/max (15): 000000020000000000000007/000000020000000000000009",
+                     "        wal archive min/max (16): 000000020000000000000007/000000020000000000000009",
                      "",
                      "        full backup: 20240527-001212F",
                      "            timestamp start/stop: 2024-05-27 00:12:12+00 / 2024-05-27 00:12:15+00",
@@ -1704,7 +1702,7 @@
                      "    cipher: aes-256-cbc",
                      "",
                      "    db (current)",
-                     "        wal archive min/max (15): 000000020000000000000007/000000020000000000000009",
+                     "        wal archive min/max (16): 000000020000000000000007/000000020000000000000009",
                      "",
                      "        full backup: 20240527-001212F",
                      "            timestamp start/stop: 2024-05-27 00:12:12+00 / 2024-05-27 00:12:15+00",
@@ -1735,7 +1733,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/postgresql/15/demo",
+                     "pg1-path=/var/lib/postgresql/16/demo",
                      "",
                      "[global]",
                      "repo1-block=y",
@@ -1775,8 +1773,8 @@
                   "output" : [
                      "       [filtered 973 lines of output]",
                      "P00   INFO: repo1: remove expired backup 20240527-001208F",
-                     "P00 DETAIL: repo1: 15-1 archive retention on backup 20240527-001212F, start = 000000020000000000000008",
-                     "P00   INFO: repo1: 15-1 remove archive, start = 000000020000000000000007, stop = 000000020000000000000007",
+                     "P00 DETAIL: repo1: 16-1 archive retention on backup 20240527-001212F, start = 000000020000000000000008",
+                     "P00   INFO: repo1: 16-1 remove archive, start = 000000020000000000000007, stop = 000000020000000000000007",
                      "P00   INFO: expire command end: completed successfully"
                   ]
                }
@@ -1824,7 +1822,7 @@
                      "       [filtered 11 lines of output]",
                      "P00   INFO: repo1: expire full backup 20240527-001212F",
                      "P00   INFO: repo1: remove expired backup 20240527-001212F",
-                     "P00   INFO: repo1: 15-1 remove archive, start = 000000020000000000000008, stop = 000000020000000000000009",
+                     "P00   INFO: repo1: 16-1 remove archive, start = 000000020000000000000008, stop = 000000020000000000000009",
                      "P00   INFO: expire command end: completed successfully"
                   ]
                }
@@ -1845,7 +1843,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/postgresql/15/demo",
+                     "pg1-path=/var/lib/postgresql/16/demo",
                      "",
                      "[global]",
                      "repo1-block=y",
@@ -1954,7 +1952,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/postgresql/15/demo",
+                     "pg1-path=/var/lib/postgresql/16/demo",
                      "",
                      "[global]",
                      "repo1-block=y",
@@ -2077,12 +2075,12 @@
                "value" : {
                   "output" : [
                      "P00   INFO: expire command begin 2.52: --exec-id=959-d03d042e --log-level-console=detail --log-level-stderr=off --no-log-timestamp --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo1-retention-archive=1 --repo1-retention-archive-type=diff --repo1-retention-diff=2 --repo1-retention-full=2 --stanza=demo",
-                     "P00 DETAIL: repo1: 15-1 archive retention on backup 20240527-001216F, start = 00000002000000000000000A, stop = 00000002000000000000000B",
-                     "P00 DETAIL: repo1: 15-1 archive retention on backup 20240527-001220F, start = 00000002000000000000000C, stop = 00000002000000000000000D",
-                     "P00 DETAIL: repo1: 15-1 archive retention on backup 20240527-001220F_20240527-001227D, start = 000000020000000000000012, stop = 000000020000000000000013",
-                     "P00 DETAIL: repo1: 15-1 archive retention on backup 20240527-001220F_20240527-001230D, start = 000000020000000000000017",
-                     "P00   INFO: repo1: 15-1 remove archive, start = 00000002000000000000000E, stop = 000000020000000000000011",
-                     "P00   INFO: repo1: 15-1 remove archive, start = 000000020000000000000014, stop = 000000020000000000000016",
+                     "P00 DETAIL: repo1: 16-1 archive retention on backup 20240527-001216F, start = 00000002000000000000000A, stop = 00000002000000000000000B",
+                     "P00 DETAIL: repo1: 16-1 archive retention on backup 20240527-001220F, start = 00000002000000000000000C, stop = 00000002000000000000000D",
+                     "P00 DETAIL: repo1: 16-1 archive retention on backup 20240527-001220F_20240527-001227D, start = 000000020000000000000012, stop = 000000020000000000000013",
+                     "P00 DETAIL: repo1: 16-1 archive retention on backup 20240527-001220F_20240527-001230D, start = 000000020000000000000017",
+                     "P00   INFO: repo1: 16-1 remove archive, start = 00000002000000000000000E, stop = 000000020000000000000011",
+                     "P00   INFO: repo1: 16-1 remove archive, start = 000000020000000000000014, stop = 000000020000000000000016",
                      "P00   INFO: expire command end: completed successfully"
                   ]
                }
@@ -2091,7 +2089,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo pg_ctlcluster 15 demo stop"
+                     "sudo pg_ctlcluster 16 demo stop"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -2123,17 +2121,17 @@
                "value" : {
                   "output" : [
                      "       [filtered 2 lines of output]",
-                     "P00 DETAIL: check '/var/lib/postgresql/15/demo' exists",
+                     "P00 DETAIL: check '/var/lib/postgresql/16/demo' exists",
                      "P00 DETAIL: remove 'global/pg_control' so cluster will not start if restore does not complete",
-                     "P00   INFO: remove invalid files/links/paths from '/var/lib/postgresql/15/demo'",
-                     "P00 DETAIL: remove invalid file '/var/lib/postgresql/15/demo/backup_label.old'",
-                     "P00 DETAIL: remove invalid file '/var/lib/postgresql/15/demo/base/1/pg_internal.init'",
+                     "P00   INFO: remove invalid files/links/paths from '/var/lib/postgresql/16/demo'",
+                     "P00 DETAIL: remove invalid file '/var/lib/postgresql/16/demo/backup_label.old'",
+                     "P00 DETAIL: remove invalid file '/var/lib/postgresql/16/demo/base/1/pg_internal.init'",
                      "       [filtered 134 lines of output]",
-                     "P01 DETAIL: restore file /var/lib/postgresql/15/demo/base/1/113 - exists and matches backup (bundle 20240527-001220F/1/58424, 8KB, 5.94%) checksum 9c6671806c84144652aa7a1e989bc2cfe3d9bd40",
-                     "P01 DETAIL: restore file /var/lib/postgresql/15/demo/base/1/112 - exists and matches backup (bundle 20240527-001220F/1/58512, 8KB, 5.98%) checksum 9890dd22d170e0de4f4d9404aba2557a33b9909b",
-                     "P01 DETAIL: restore file /var/lib/postgresql/15/demo/PG_VERSION - exists and matches backup (bundle 20240527-001220F/1/58600, 3B, 5.98%) checksum 587b596f04f7db9c2cad3d6b87dd2b3a05de4f35",
-                     "P01 DETAIL: restore file /var/lib/postgresql/15/demo/global/2695 - exists and matches backup (bundle 20240527-001220F/1/58624, 16KB, 6.05%) checksum 843d45d7c839660378249350bae98ab512a70e30",
-                     "P01 DETAIL: restore file /var/lib/postgresql/15/demo/global/2694 - exists and matches backup (bundle 20240527-001220F/1/58832, 16KB, 6.12%) checksum 88e1fb6d0708cf9fa40378bf8a02d167d4f3f7e9",
+                     "P01 DETAIL: restore file /var/lib/postgresql/16/demo/base/1/113 - exists and matches backup (bundle 20240527-001220F/1/58424, 8KB, 5.94%) checksum 9c6671806c84144652aa7a1e989bc2cfe3d9bd40",
+                     "P01 DETAIL: restore file /var/lib/postgresql/16/demo/base/1/112 - exists and matches backup (bundle 20240527-001220F/1/58512, 8KB, 5.98%) checksum 9890dd22d170e0de4f4d9404aba2557a33b9909b",
+                     "P01 DETAIL: restore file /var/lib/postgresql/16/demo/PG_VERSION - exists and matches backup (bundle 20240527-001220F/1/58600, 3B, 5.98%) checksum 587b596f04f7db9c2cad3d6b87dd2b3a05de4f35",
+                     "P01 DETAIL: restore file /var/lib/postgresql/16/demo/global/2695 - exists and matches backup (bundle 20240527-001220F/1/58624, 16KB, 6.05%) checksum 843d45d7c839660378249350bae98ab512a70e30",
+                     "P01 DETAIL: restore file /var/lib/postgresql/16/demo/global/2694 - exists and matches backup (bundle 20240527-001220F/1/58832, 16KB, 6.12%) checksum 88e1fb6d0708cf9fa40378bf8a02d167d4f3f7e9",
                      "       [filtered 866 lines of output]"
                   ]
                }
@@ -2142,7 +2140,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo pg_ctlcluster 15 demo start"
+                     "sudo pg_ctlcluster 16 demo start"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -2275,7 +2273,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo -u postgres du -sh /var/lib/postgresql/15/demo/base/32768"
+                     "sudo -u postgres du -sh /var/lib/postgresql/16/demo/base/32768"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -2285,7 +2283,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "7.3M\t/var/lib/postgresql/15/demo/base/32768"
+                     "7.3M\t/var/lib/postgresql/16/demo/base/32768"
                   ]
                }
             },
@@ -2340,7 +2338,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo pg_ctlcluster 15 demo stop"
+                     "sudo pg_ctlcluster 16 demo stop"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -2367,7 +2365,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo pg_ctlcluster 15 demo start"
+                     "sudo pg_ctlcluster 16 demo start"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -2440,7 +2438,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo -u postgres du -sh /var/lib/postgresql/15/demo/base/32768"
+                     "sudo -u postgres du -sh /var/lib/postgresql/16/demo/base/32768"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -2450,7 +2448,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "8.0K\t/var/lib/postgresql/15/demo/base/32768"
+                     "8.0K\t/var/lib/postgresql/16/demo/base/32768"
                   ]
                }
             },
@@ -2679,7 +2677,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo pg_ctlcluster 15 demo stop"
+                     "sudo pg_ctlcluster 16 demo stop"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -2707,7 +2705,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo rm /var/log/postgresql/postgresql-15-demo.log"
+                     "sudo rm /var/log/postgresql/postgresql-16-demo.log"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -2720,7 +2718,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo pg_ctlcluster 15 demo start"
+                     "sudo pg_ctlcluster 16 demo start"
                   ],
                   "err-expect" : "1",
                   "highlight" : {
@@ -2767,7 +2765,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo rm /var/log/postgresql/postgresql-15-demo.log"
+                     "sudo rm /var/log/postgresql/postgresql-16-demo.log"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -2780,7 +2778,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo -u postgres cat /var/lib/postgresql/15/demo/postgresql.auto.conf"
+                     "sudo -u postgres cat /var/lib/postgresql/16/demo/postgresql.auto.conf"
                   ],
                   "highlight" : {
                      "filter" : true,
@@ -2809,7 +2807,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo pg_ctlcluster 15 demo start"
+                     "sudo pg_ctlcluster 16 demo start"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -2863,7 +2861,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo -u postgres cat /var/log/postgresql/postgresql-15-demo.log"
+                     "sudo -u postgres cat /var/log/postgresql/postgresql-16-demo.log"
                   ],
                   "highlight" : {
                      "filter" : true,
@@ -2902,7 +2900,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo pg_ctlcluster 15 demo stop"
+                     "sudo pg_ctlcluster 16 demo stop"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -2959,7 +2957,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: stanza-delete command begin 2.52: --exec-id=1454-9a0b7d7f --log-level-console=info --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/postgresql/15/demo --repo=1 --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --stanza=demo",
+                     "P00   INFO: stanza-delete command begin 2.52: --exec-id=1454-9a0b7d7f --log-level-console=info --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/postgresql/16/demo --repo=1 --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --stanza=demo",
                      "P00   INFO: stanza-delete command end: completed successfully"
                   ]
                }
@@ -2968,7 +2966,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo pg_ctlcluster 15 demo start"
+                     "sudo pg_ctlcluster 16 demo start"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -3011,7 +3009,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/postgresql/15/demo",
+                     "pg1-path=/var/lib/postgresql/16/demo",
                      "",
                      "[global]",
                      "process-max=4",
@@ -3082,7 +3080,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: stanza-create command begin 2.52: --exec-id=1519-ab9fe3da --log-level-console=info --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/postgresql/15/demo --repo2-azure-account=<redacted> --repo2-azure-container=demo-container --repo2-azure-key=<redacted> --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo2-path=/demo-repo --repo2-type=azure --stanza=demo",
+                     "P00   INFO: stanza-create command begin 2.52: --exec-id=1519-ab9fe3da --log-level-console=info --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/postgresql/16/demo --repo2-azure-account=<redacted> --repo2-azure-container=demo-container --repo2-azure-key=<redacted> --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo2-path=/demo-repo --repo2-type=azure --stanza=demo",
                      "P00   INFO: stanza-create for stanza 'demo' on repo1",
                      "P00   INFO: stanza-create for stanza 'demo' on repo2",
                      "P00   INFO: stanza-create command end: completed successfully"
@@ -3111,7 +3109,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: backup command begin 2.52: --exec-id=1527-86384be4 --log-level-console=info --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/postgresql/15/demo --process-max=4 --repo=2 --repo2-azure-account=<redacted> --repo2-azure-container=demo-container --repo2-azure-key=<redacted> --repo1-block --repo1-bundle --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo2-path=/demo-repo --repo1-retention-diff=2 --repo1-retention-full=2 --repo2-retention-full=4 --repo2-type=azure --stanza=demo --start-fast",
+                     "P00   INFO: backup command begin 2.52: --exec-id=1527-86384be4 --log-level-console=info --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/postgresql/16/demo --process-max=4 --repo=2 --repo2-azure-account=<redacted> --repo2-azure-container=demo-container --repo2-azure-key=<redacted> --repo1-block --repo1-bundle --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo2-path=/demo-repo --repo1-retention-diff=2 --repo1-retention-full=2 --repo2-retention-full=4 --repo2-type=azure --stanza=demo --start-fast",
                      "P00   WARN: no prior backup exists, incr backup has been changed to full",
                      "P00   INFO: execute non-exclusive backup start: backup begins after the requested immediate checkpoint completes",
                      "P00   INFO: backup start archive = 00000005000000000000001B, lsn = 0/1B000028",
@@ -3164,7 +3162,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/postgresql/15/demo",
+                     "pg1-path=/var/lib/postgresql/16/demo",
                      "",
                      "[global]",
                      "process-max=4",
@@ -3272,7 +3270,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: backup command begin 2.52: --exec-id=1585-94094bc8 --log-level-console=info --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/postgresql/15/demo --process-max=4 --repo=3 --repo2-azure-account=<redacted> --repo2-azure-container=demo-container --repo2-azure-key=<redacted> --repo1-block --repo1-bundle --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo2-path=/demo-repo --repo3-path=/demo-repo --repo1-retention-diff=2 --repo1-retention-full=2 --repo2-retention-full=4 --repo3-retention-full=4 --repo3-s3-bucket=demo-bucket --repo3-s3-endpoint=s3.us-east-1.amazonaws.com --repo3-s3-key=<redacted> --repo3-s3-key-secret=<redacted> --repo3-s3-region=us-east-1 --repo2-type=azure --repo3-type=s3 --stanza=demo --start-fast",
+                     "P00   INFO: backup command begin 2.52: --exec-id=1585-94094bc8 --log-level-console=info --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/postgresql/16/demo --process-max=4 --repo=3 --repo2-azure-account=<redacted> --repo2-azure-container=demo-container --repo2-azure-key=<redacted> --repo1-block --repo1-bundle --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo2-path=/demo-repo --repo3-path=/demo-repo --repo1-retention-diff=2 --repo1-retention-full=2 --repo2-retention-full=4 --repo3-retention-full=4 --repo3-s3-bucket=demo-bucket --repo3-s3-endpoint=s3.us-east-1.amazonaws.com --repo3-s3-key=<redacted> --repo3-s3-key-secret=<redacted> --repo3-s3-region=us-east-1 --repo2-type=azure --repo3-type=s3 --stanza=demo --start-fast",
                      "P00   WARN: no prior backup exists, incr backup has been changed to full",
                      "P00   INFO: execute non-exclusive backup start: backup begins after the requested immediate checkpoint completes",
                      "P00   INFO: backup start archive = 00000005000000000000001C, lsn = 0/1C000028",
@@ -3325,7 +3323,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/postgresql/15/demo",
+                     "pg1-path=/var/lib/postgresql/16/demo",
                      "",
                      "[global]",
                      "process-max=4",
@@ -3508,7 +3506,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: backup command begin 2.52: --exec-id=1660-9aa2304e --log-level-console=info --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/postgresql/15/demo --process-max=4 --repo=4 --repo2-azure-account=<redacted> --repo2-azure-container=demo-container --repo2-azure-key=<redacted> --repo1-block --repo1-bundle --repo4-bundle --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo2-path=/demo-repo --repo3-path=/demo-repo --repo4-path=/demo-repo --repo1-retention-diff=2 --repo1-retention-full=2 --repo2-retention-full=4 --repo3-retention-full=4 --repo3-s3-bucket=demo-bucket --repo3-s3-endpoint=s3.us-east-1.amazonaws.com --repo3-s3-key=<redacted> --repo3-s3-key-secret=<redacted> --repo3-s3-region=us-east-1 --repo4-sftp-host=sftp-server --repo4-sftp-host-key-hash-type=sha1 --repo4-sftp-host-user=pgbackrest --repo4-sftp-private-key-file=/var/lib/postgresql/.ssh/id_rsa_sftp --repo4-sftp-public-key-file=/var/lib/postgresql/.ssh/id_rsa_sftp.pub --repo2-type=azure --repo3-type=s3 --repo4-type=sftp --stanza=demo --start-fast",
+                     "P00   INFO: backup command begin 2.52: --exec-id=1660-9aa2304e --log-level-console=info --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/postgresql/16/demo --process-max=4 --repo=4 --repo2-azure-account=<redacted> --repo2-azure-container=demo-container --repo2-azure-key=<redacted> --repo1-block --repo1-bundle --repo4-bundle --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo2-path=/demo-repo --repo3-path=/demo-repo --repo4-path=/demo-repo --repo1-retention-diff=2 --repo1-retention-full=2 --repo2-retention-full=4 --repo3-retention-full=4 --repo3-s3-bucket=demo-bucket --repo3-s3-endpoint=s3.us-east-1.amazonaws.com --repo3-s3-key=<redacted> --repo3-s3-key-secret=<redacted> --repo3-s3-region=us-east-1 --repo4-sftp-host=sftp-server --repo4-sftp-host-key-hash-type=sha1 --repo4-sftp-host-user=pgbackrest --repo4-sftp-private-key-file=/var/lib/postgresql/.ssh/id_rsa_sftp --repo4-sftp-public-key-file=/var/lib/postgresql/.ssh/id_rsa_sftp.pub --repo2-type=azure --repo3-type=s3 --repo4-type=sftp --stanza=demo --start-fast",
                      "P00   WARN: option 'repo4-retention-full' is not set for 'repo4-retention-full-type=count', the repository may run out of space",
                      "            HINT: to retain full backups indefinitely (without warning), set option 'repo4-retention-full' to the maximum.",
                      "P00   WARN: no prior backup exists, incr backup has been changed to full",
@@ -3552,7 +3550,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/postgresql/15/demo",
+                     "pg1-path=/var/lib/postgresql/16/demo",
                      "",
                      "[global]",
                      "process-max=4",
@@ -3601,7 +3599,7 @@
                   "id" : "repo1",
                   "image" : "pgbackrest/doc:debian",
                   "name" : "repository",
-                  "option" : "-m 512m -v /sys/fs/cgroup:/sys/fs/cgroup:rw -v /tmp/$(mktemp -d):/run",
+                  "option" : "-m 512m",
                   "os" : "debian",
                   "update-hosts" : true
                },
@@ -3938,7 +3936,7 @@
                            "value" : "pg-primary"
                         },
                         "pg1-path" : {
-                           "value" : "/var/lib/postgresql/15/demo"
+                           "value" : "/var/lib/postgresql/16/demo"
                         }
                      },
                      "global" : {
@@ -3962,7 +3960,7 @@
                   "config" : [
                      "[demo]",
                      "pg1-host=pg-primary",
-                     "pg1-path=/var/lib/postgresql/15/demo",
+                     "pg1-path=/var/lib/postgresql/16/demo",
                      "",
                      "[global]",
                      "repo1-path=/var/lib/pgbackrest",
@@ -3978,7 +3976,7 @@
                   "option" : {
                      "demo" : {
                         "pg1-path" : {
-                           "value" : "/var/lib/postgresql/15/demo"
+                           "value" : "/var/lib/postgresql/16/demo"
                         }
                      },
                      "global" : {
@@ -4002,7 +4000,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/postgresql/15/demo",
+                     "pg1-path=/var/lib/postgresql/16/demo",
                      "",
                      "[global]",
                      "log-level-file=detail",
@@ -4071,7 +4069,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo pg_ctlcluster 15 demo stop"
+                     "sudo pg_ctlcluster 16 demo stop"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -4097,7 +4095,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo pg_ctlcluster 15 demo start"
+                     "sudo pg_ctlcluster 16 demo start"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -4149,7 +4147,7 @@
                   "config" : [
                      "[demo]",
                      "pg1-host=pg-primary",
-                     "pg1-path=/var/lib/postgresql/15/demo",
+                     "pg1-path=/var/lib/postgresql/16/demo",
                      "",
                      "[global]",
                      "process-max=3",
@@ -4198,7 +4196,7 @@
                      "    cipher: none",
                      "",
                      "    db (current)",
-                     "        wal archive min/max (15): 000000060000000000000025/000000060000000000000027",
+                     "        wal archive min/max (16): 000000060000000000000025/000000060000000000000027",
                      "",
                      "        full backup: 20240527-001354F",
                      "            timestamp start/stop: 2024-05-27 00:13:54+00 / 2024-05-27 00:13:57+00",
@@ -4345,7 +4343,7 @@
                   "id" : "pg2",
                   "image" : "pgbackrest/doc:debian",
                   "name" : "pg-standby",
-                  "option" : "-m 512m -v /sys/fs/cgroup:/sys/fs/cgroup:rw -v /tmp/$(mktemp -d):/run",
+                  "option" : "-m 512m",
                   "os" : "debian",
                   "update-hosts" : true
                },
@@ -4580,7 +4578,7 @@
                   "option" : {
                      "demo" : {
                         "pg1-path" : {
-                           "value" : "/var/lib/postgresql/15/demo"
+                           "value" : "/var/lib/postgresql/16/demo"
                         }
                      },
                      "global" : {
@@ -4603,7 +4601,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/postgresql/15/demo",
+                     "pg1-path=/var/lib/postgresql/16/demo",
                      "",
                      "[global]",
                      "log-level-file=detail",
@@ -4615,7 +4613,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo pg_createcluster 15 demo"
+                     "sudo pg_createcluster 16 demo"
                   ],
                   "host" : "pg-standby",
                   "load-env" : true,
@@ -4641,7 +4639,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo -u postgres cat /var/lib/postgresql/15/demo/postgresql.auto.conf"
+                     "sudo -u postgres cat /var/lib/postgresql/16/demo/postgresql.auto.conf"
                   ],
                   "host" : "pg-standby",
                   "load-env" : true,
@@ -4677,7 +4675,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "cat /root/postgresql.common.conf >> /etc/postgresql/15/demo/postgresql.conf"
+                     "cat /root/postgresql.common.conf >> /etc/postgresql/16/demo/postgresql.conf"
                   ],
                   "host" : "pg-standby",
                   "load-env" : true,
@@ -4688,7 +4686,7 @@
             },
             {
                "key" : {
-                  "file" : "/etc/postgresql/15/demo/postgresql.conf",
+                  "file" : "/etc/postgresql/16/demo/postgresql.conf",
                   "host" : "pg-standby",
                   "option" : {
                      "archive_command" : {
@@ -4723,7 +4721,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo rm /var/log/postgresql/postgresql-15-demo.log"
+                     "sudo rm /var/log/postgresql/postgresql-16-demo.log"
                   ],
                   "host" : "pg-standby",
                   "load-env" : true,
@@ -4736,7 +4734,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo pg_ctlcluster 15 demo start"
+                     "sudo pg_ctlcluster 16 demo start"
                   ],
                   "host" : "pg-standby",
                   "load-env" : true,
@@ -4762,7 +4760,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo -u postgres cat /var/log/postgresql/postgresql-15-demo.log"
+                     "sudo -u postgres cat /var/log/postgresql/postgresql-16-demo.log"
                   ],
                   "highlight" : {
                      "filter" : true,
@@ -4922,7 +4920,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: check command begin 2.52: --exec-id=459-f166a274 --log-level-console=info --log-level-file=detail --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/postgresql/15/demo --repo1-host=repository --stanza=demo",
+                     "P00   INFO: check command begin 2.52: --exec-id=459-f166a274 --log-level-console=info --log-level-file=detail --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/postgresql/16/demo --repo1-host=repository --stanza=demo",
                      "P00   INFO: check repo1 (standby)",
                      "P00   INFO: switch wal not performed because this is a standby",
                      "P00   INFO: check command end: completed successfully"
@@ -4954,7 +4952,7 @@
                   "cmd" : [
                      "sudo -u postgres sh -c 'echo \\",
                      "    \"host    replication     replicator      172.17.0.8/32           md5\" \\",
-                     "    >> /etc/postgresql/15/demo/pg_hba.conf'"
+                     "    >> /etc/postgresql/16/demo/pg_hba.conf'"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -4967,7 +4965,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo pg_ctlcluster 15 demo reload"
+                     "sudo pg_ctlcluster 16 demo reload"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -4992,7 +4990,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/postgresql/15/demo",
+                     "pg1-path=/var/lib/postgresql/16/demo",
                      "recovery-option=primary_conninfo=host=172.17.0.6 port=5432 user=replicator",
                      "",
                      "[global]",
@@ -5033,7 +5031,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo pg_ctlcluster 15 demo stop"
+                     "sudo pg_ctlcluster 16 demo stop"
                   ],
                   "host" : "pg-standby",
                   "load-env" : true,
@@ -5059,7 +5057,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo -u postgres cat /var/lib/postgresql/15/demo/postgresql.auto.conf"
+                     "sudo -u postgres cat /var/lib/postgresql/16/demo/postgresql.auto.conf"
                   ],
                   "host" : "pg-standby",
                   "load-env" : true,
@@ -5096,7 +5094,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo rm /var/log/postgresql/postgresql-15-demo.log"
+                     "sudo rm /var/log/postgresql/postgresql-16-demo.log"
                   ],
                   "host" : "pg-standby",
                   "load-env" : true,
@@ -5109,7 +5107,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo pg_ctlcluster 15 demo start"
+                     "sudo pg_ctlcluster 16 demo start"
                   ],
                   "host" : "pg-standby",
                   "load-env" : true,
@@ -5135,7 +5133,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo -u postgres cat /var/log/postgresql/postgresql-15-demo.log"
+                     "sudo -u postgres cat /var/log/postgresql/postgresql-16-demo.log"
                   ],
                   "highlight" : {
                      "filter" : true,
@@ -5227,7 +5225,7 @@
                   "id" : "pgalt",
                   "image" : "pgbackrest/doc:debian",
                   "name" : "pg-alt",
-                  "option" : "-m 512m -v /sys/fs/cgroup:/sys/fs/cgroup:rw -v /tmp/$(mktemp -d):/run",
+                  "option" : "-m 512m",
                   "os" : "debian",
                   "update-hosts" : true
                },
@@ -5462,7 +5460,7 @@
                   "option" : {
                      "demo-alt" : {
                         "pg1-path" : {
-                           "value" : "/var/lib/postgresql/15/demo"
+                           "value" : "/var/lib/postgresql/16/demo"
                         }
                      },
                      "global" : {
@@ -5485,7 +5483,7 @@
                "value" : {
                   "config" : [
                      "[demo-alt]",
-                     "pg1-path=/var/lib/postgresql/15/demo",
+                     "pg1-path=/var/lib/postgresql/16/demo",
                      "",
                      "[global]",
                      "log-level-file=detail",
@@ -5503,7 +5501,7 @@
                            "value" : "pg-alt"
                         },
                         "pg1-path" : {
-                           "value" : "/var/lib/postgresql/15/demo"
+                           "value" : "/var/lib/postgresql/16/demo"
                         }
                      }
                   }
@@ -5513,11 +5511,11 @@
                   "config" : [
                      "[demo]",
                      "pg1-host=pg-primary",
-                     "pg1-path=/var/lib/postgresql/15/demo",
+                     "pg1-path=/var/lib/postgresql/16/demo",
                      "",
                      "[demo-alt]",
                      "pg1-host=pg-alt",
-                     "pg1-path=/var/lib/postgresql/15/demo",
+                     "pg1-path=/var/lib/postgresql/16/demo",
                      "",
                      "[global]",
                      "process-max=3",
@@ -5531,8 +5529,8 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo -u postgres /usr/lib/postgresql/15/bin/initdb \\",
-                     "    -D /var/lib/postgresql/15/demo -k -A peer"
+                     "sudo -u postgres /usr/lib/postgresql/16/bin/initdb \\",
+                     "    -D /var/lib/postgresql/16/demo -k -A peer"
                   ],
                   "host" : "pg-alt",
                   "load-env" : true,
@@ -5545,7 +5543,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo pg_createcluster 15 demo"
+                     "sudo pg_createcluster 16 demo"
                   ],
                   "host" : "pg-alt",
                   "load-env" : true,
@@ -5555,9 +5553,9 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "Configuring already existing cluster (configuration: /etc/postgresql/15/demo, data: /var/lib/postgresql/15/demo, owner: 102:103)",
+                     "Configuring already existing cluster (configuration: /etc/postgresql/16/demo, data: /var/lib/postgresql/16/demo, owner: 102:103)",
                      "Ver Cluster Port Status Owner    Data directory              Log file",
-                     "15  demo    5432 down   postgres /var/lib/postgresql/15/demo /var/log/postgresql/postgresql-15-demo.log"
+                     "16  demo    5432 down   postgres /var/lib/postgresql/16/demo /var/log/postgresql/postgresql-16-demo.log"
                   ]
                }
             },
@@ -5565,7 +5563,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "cat /root/postgresql.common.conf >> /etc/postgresql/15/demo/postgresql.conf"
+                     "cat /root/postgresql.common.conf >> /etc/postgresql/16/demo/postgresql.conf"
                   ],
                   "host" : "pg-alt",
                   "load-env" : true,
@@ -5576,7 +5574,7 @@
             },
             {
                "key" : {
-                  "file" : "/etc/postgresql/15/demo/postgresql.conf",
+                  "file" : "/etc/postgresql/16/demo/postgresql.conf",
                   "host" : "pg-alt",
                   "option" : {
                      "archive_command" : {
@@ -5607,7 +5605,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo pg_ctlcluster 15 demo restart"
+                     "sudo pg_ctlcluster 16 demo restart"
                   ],
                   "host" : "pg-alt",
                   "load-env" : true,
@@ -5650,7 +5648,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: stanza-create command begin 2.52: --exec-id=359-b68a4769 --log-level-console=info --log-level-file=detail --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/postgresql/15/demo --repo1-host=repository --stanza=demo-alt",
+                     "P00   INFO: stanza-create command begin 2.52: --exec-id=359-b68a4769 --log-level-console=info --log-level-file=detail --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/postgresql/16/demo --repo1-host=repository --stanza=demo-alt",
                      "P00   INFO: stanza-create for stanza 'demo-alt' on repo1",
                      "P00   INFO: stanza-create command end: completed successfully"
                   ]
@@ -5801,7 +5799,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/postgresql/15/demo",
+                     "pg1-path=/var/lib/postgresql/16/demo",
                      "",
                      "[global]",
                      "archive-async=y",
@@ -5846,7 +5844,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/postgresql/15/demo",
+                     "pg1-path=/var/lib/postgresql/16/demo",
                      "recovery-option=primary_conninfo=host=172.17.0.6 port=5432 user=replicator",
                      "",
                      "[global]",
@@ -5885,7 +5883,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo pg_ctlcluster 15 demo restart"
+                     "sudo pg_ctlcluster 16 demo restart"
                   ],
                   "host" : "pg-standby",
                   "load-env" : true,
@@ -5946,7 +5944,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: check command begin 2.52: --exec-id=2232-1051b129 --log-level-console=info --log-level-file=detail --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/postgresql/15/demo --repo1-host=repository --stanza=demo",
+                     "P00   INFO: check command begin 2.52: --exec-id=2232-1051b129 --log-level-console=info --log-level-file=detail --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/postgresql/16/demo --repo1-host=repository --stanza=demo",
                      "P00   INFO: check repo1 configuration (primary)",
                      "P00   INFO: check repo1 archive for WAL (primary)",
                      "P00   INFO: WAL segment 00000006000000000000002F successfully archived to '/var/lib/pgbackrest/archive/demo/15-1/0000000600000000/00000006000000000000002F-4467eb538234746215502dace8cbd1877df60e3e.gz' on repo1",
@@ -5976,14 +5974,14 @@
                "value" : {
                   "output" : [
                      "-------------------PROCESS START-------------------",
-                     "P00   INFO: archive-push:async command begin 2.52: [/var/lib/postgresql/15/demo/pg_wal] --archive-async --exec-id=2218-2a6fe845 --log-level-console=off --log-level-file=detail --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/postgresql/15/demo --process-max=2 --repo1-host=repository --spool-path=/var/spool/pgbackrest --stanza=demo",
+                     "P00   INFO: archive-push:async command begin 2.52: [/var/lib/postgresql/16/demo/pg_wal] --archive-async --exec-id=2218-2a6fe845 --log-level-console=off --log-level-file=detail --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/postgresql/16/demo --process-max=2 --repo1-host=repository --spool-path=/var/spool/pgbackrest --stanza=demo",
                      "P00   INFO: push 2 WAL file(s) to archive: 00000006000000000000002A...00000006000000000000002B",
                      "P02 DETAIL: pushed WAL file '00000006000000000000002B' to the archive",
                      "P01 DETAIL: pushed WAL file '00000006000000000000002A' to the archive",
                      "P00   INFO: archive-push:async command end: completed successfully",
                      "",
                      "-------------------PROCESS START-------------------",
-                     "P00   INFO: archive-push:async command begin 2.52: [/var/lib/postgresql/15/demo/pg_wal] --archive-async --exec-id=2238-2fc0bba2 --log-level-console=off --log-level-file=detail --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/postgresql/15/demo --process-max=2 --repo1-host=repository --spool-path=/var/spool/pgbackrest --stanza=demo",
+                     "P00   INFO: archive-push:async command begin 2.52: [/var/lib/postgresql/16/demo/pg_wal] --archive-async --exec-id=2238-2fc0bba2 --log-level-console=off --log-level-file=detail --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/postgresql/16/demo --process-max=2 --repo1-host=repository --spool-path=/var/spool/pgbackrest --stanza=demo",
                      "P00   INFO: push 4 WAL file(s) to archive: 00000006000000000000002C...00000006000000000000002F",
                      "P02 DETAIL: pushed WAL file '00000006000000000000002D' to the archive",
                      "P01 DETAIL: pushed WAL file '00000006000000000000002C' to the archive",
@@ -6026,23 +6024,23 @@
                "value" : {
                   "output" : [
                      "-------------------PROCESS START-------------------",
-                     "P00   INFO: archive-get:async command begin 2.52: [000000060000000000000026, 000000060000000000000027, 000000060000000000000028, 000000060000000000000029, 00000006000000000000002A, 00000006000000000000002B, 00000006000000000000002C, 00000006000000000000002D] --archive-async --exec-id=661-1d27c864 --log-level-console=off --log-level-file=detail --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/postgresql/15/demo --process-max=2 --repo1-host=repository --spool-path=/var/spool/pgbackrest --stanza=demo",
+                     "P00   INFO: archive-get:async command begin 2.52: [000000060000000000000026, 000000060000000000000027, 000000060000000000000028, 000000060000000000000029, 00000006000000000000002A, 00000006000000000000002B, 00000006000000000000002C, 00000006000000000000002D] --archive-async --exec-id=661-1d27c864 --log-level-console=off --log-level-file=detail --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/postgresql/16/demo --process-max=2 --repo1-host=repository --spool-path=/var/spool/pgbackrest --stanza=demo",
                      "P00   INFO: get 8 WAL file(s) from archive: 000000060000000000000026...00000006000000000000002D",
-                     "P02 DETAIL: found 000000060000000000000027 in the repo1: 15-1 archive",
-                     "P01 DETAIL: found 000000060000000000000026 in the repo1: 15-1 archive",
-                     "P02 DETAIL: found 000000060000000000000028 in the repo1: 15-1 archive",
-                     "P01 DETAIL: found 000000060000000000000029 in the repo1: 15-1 archive",
+                     "P02 DETAIL: found 000000060000000000000027 in the repo1: 16-1 archive",
+                     "P01 DETAIL: found 000000060000000000000026 in the repo1: 16-1 archive",
+                     "P02 DETAIL: found 000000060000000000000028 in the repo1: 16-1 archive",
+                     "P01 DETAIL: found 000000060000000000000029 in the repo1: 16-1 archive",
                      "P00 DETAIL: unable to find 00000006000000000000002A in the archive",
                      "P00   INFO: archive-get:async command end: completed successfully",
                      "       [filtered 14 lines of output]",
-                     "P00   INFO: archive-get:async command begin 2.52: [00000006000000000000002A, 00000006000000000000002B, 00000006000000000000002C, 00000006000000000000002D, 00000006000000000000002E, 00000006000000000000002F, 000000060000000000000030, 000000060000000000000031] --archive-async --exec-id=711-c4d8825b --log-level-console=off --log-level-file=detail --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/postgresql/15/demo --process-max=2 --repo1-host=repository --spool-path=/var/spool/pgbackrest --stanza=demo",
+                     "P00   INFO: archive-get:async command begin 2.52: [00000006000000000000002A, 00000006000000000000002B, 00000006000000000000002C, 00000006000000000000002D, 00000006000000000000002E, 00000006000000000000002F, 000000060000000000000030, 000000060000000000000031] --archive-async --exec-id=711-c4d8825b --log-level-console=off --log-level-file=detail --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/postgresql/16/demo --process-max=2 --repo1-host=repository --spool-path=/var/spool/pgbackrest --stanza=demo",
                      "P00   INFO: get 8 WAL file(s) from archive: 00000006000000000000002A...000000060000000000000031",
-                     "P01 DETAIL: found 00000006000000000000002A in the repo1: 15-1 archive",
-                     "P02 DETAIL: found 00000006000000000000002B in the repo1: 15-1 archive",
-                     "P01 DETAIL: found 00000006000000000000002C in the repo1: 15-1 archive",
-                     "P02 DETAIL: found 00000006000000000000002D in the repo1: 15-1 archive",
-                     "P01 DETAIL: found 00000006000000000000002E in the repo1: 15-1 archive",
-                     "P02 DETAIL: found 00000006000000000000002F in the repo1: 15-1 archive",
+                     "P01 DETAIL: found 00000006000000000000002A in the repo1: 16-1 archive",
+                     "P02 DETAIL: found 00000006000000000000002B in the repo1: 16-1 archive",
+                     "P01 DETAIL: found 00000006000000000000002C in the repo1: 16-1 archive",
+                     "P02 DETAIL: found 00000006000000000000002D in the repo1: 16-1 archive",
+                     "P01 DETAIL: found 00000006000000000000002E in the repo1: 16-1 archive",
+                     "P02 DETAIL: found 00000006000000000000002F in the repo1: 16-1 archive",
                      "P00 DETAIL: unable to find 000000060000000000000030 in the archive",
                      "P00   INFO: archive-get:async command end: completed successfully",
                      "       [filtered 11 lines of output]"
@@ -6077,7 +6075,7 @@
                            "value" : "pg-standby"
                         },
                         "pg2-path" : {
-                           "value" : "/var/lib/postgresql/15/demo"
+                           "value" : "/var/lib/postgresql/16/demo"
                         }
                      },
                      "global" : {
@@ -6092,13 +6090,13 @@
                   "config" : [
                      "[demo]",
                      "pg1-host=pg-primary",
-                     "pg1-path=/var/lib/postgresql/15/demo",
+                     "pg1-path=/var/lib/postgresql/16/demo",
                      "pg2-host=pg-standby",
-                     "pg2-path=/var/lib/postgresql/15/demo",
+                     "pg2-path=/var/lib/postgresql/16/demo",
                      "",
                      "[demo-alt]",
                      "pg1-host=pg-alt",
-                     "pg1-path=/var/lib/postgresql/15/demo",
+                     "pg1-path=/var/lib/postgresql/16/demo",
                      "",
                      "[global]",
                      "backup-standby=y",
@@ -6136,9 +6134,9 @@
                      "P00   INFO: wait for replay on the standby to reach 0/31000028",
                      "P00   INFO: replay on the standby reached 0/31000028",
                      "P00   INFO: check archive for prior segment 000000060000000000000030",
-                     "P01 DETAIL: backup file pg-primary:/var/lib/postgresql/15/demo/global/pg_control (8KB, 0.53%) checksum 11d7c5ef859f173b0f65341dd0ef4740b5d4129c",
-                     "P01 DETAIL: match file from prior backup pg-primary:/var/lib/postgresql/15/demo/pg_logical/replorigin_checkpoint (8B, 0.53%) checksum 347fc8f2df71bd4436e38bd1516ccd7ea0d46532",
-                     "P02 DETAIL: backup file pg-standby:/var/lib/postgresql/15/demo/base/5/1249 (456KB, 31.18%) checksum da07d6e522b4e15858f0049de1de09b16d6ab144",
+                     "P01 DETAIL: backup file pg-primary:/var/lib/postgresql/16/demo/global/pg_control (8KB, 0.53%) checksum 11d7c5ef859f173b0f65341dd0ef4740b5d4129c",
+                     "P01 DETAIL: match file from prior backup pg-primary:/var/lib/postgresql/16/demo/pg_logical/replorigin_checkpoint (8B, 0.53%) checksum 347fc8f2df71bd4436e38bd1516ccd7ea0d46532",
+                     "P02 DETAIL: backup file pg-standby:/var/lib/postgresql/16/demo/base/5/1249 (456KB, 31.18%) checksum da07d6e522b4e15858f0049de1de09b16d6ab144",
                      "       [filtered 1276 lines of output]"
                   ]
                }
@@ -6147,7 +6145,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo pg_ctlcluster 15 demo stop"
+                     "sudo pg_ctlcluster 16 demo stop"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -6160,7 +6158,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo pg_ctlcluster 15 demo stop"
+                     "sudo pg_ctlcluster 16 demo stop"
                   ],
                   "host" : "pg-standby",
                   "load-env" : true,
@@ -6173,8 +6171,8 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo -u postgres /usr/lib/postgresql/16/bin/initdb \\",
-                     "    -D /var/lib/postgresql/16/demo -k -A peer"
+                     "sudo -u postgres /usr/lib/postgresql/17/bin/initdb \\",
+                     "    -D /var/lib/postgresql/17/demo -k -A peer"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -6187,7 +6185,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo pg_createcluster 16 demo"
+                     "sudo pg_createcluster 17 demo"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -6201,13 +6199,13 @@
                   "bash-wrap" : true,
                   "cmd" : [
                      "sudo -u postgres sh -c 'cd /var/lib/postgresql && \\",
-                     "    /usr/lib/postgresql/16/bin/pg_upgrade \\",
-                     "    --old-bindir=/usr/lib/postgresql/15/bin \\",
-                     "    --new-bindir=/usr/lib/postgresql/16/bin \\",
-                     "    --old-datadir=/var/lib/postgresql/15/demo \\",
-                     "    --new-datadir=/var/lib/postgresql/16/demo \\",
-                     "    --old-options=\" -c config_file=/etc/postgresql/15/demo/postgresql.conf\" \\",
-                     "    --new-options=\" -c config_file=/etc/postgresql/16/demo/postgresql.conf\"'"
+                     "    /usr/lib/postgresql/17/bin/pg_upgrade \\",
+                     "    --old-bindir=/usr/lib/postgresql/16/bin \\",
+                     "    --new-bindir=/usr/lib/postgresql/17/bin \\",
+                     "    --old-datadir=/var/lib/postgresql/16/demo \\",
+                     "    --new-datadir=/var/lib/postgresql/17/demo \\",
+                     "    --old-options=\" -c config_file=/etc/postgresql/16/demo/postgresql.conf\" \\",
+                     "    --new-options=\" -c config_file=/etc/postgresql/17/demo/postgresql.conf\"'"
                   ],
                   "highlight" : {
                      "filter" : true,
@@ -6238,7 +6236,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "cat /root/postgresql.common.conf >> /etc/postgresql/16/demo/postgresql.conf"
+                     "cat /root/postgresql.common.conf >> /etc/postgresql/17/demo/postgresql.conf"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -6249,7 +6247,7 @@
             },
             {
                "key" : {
-                  "file" : "/etc/postgresql/16/demo/postgresql.conf",
+                  "file" : "/etc/postgresql/17/demo/postgresql.conf",
                   "host" : "pg-primary",
                   "option" : {
                      "archive_command" : {
@@ -6283,7 +6281,7 @@
                   "option" : {
                      "demo" : {
                         "pg1-path" : {
-                           "value" : "/var/lib/postgresql/16/demo"
+                           "value" : "/var/lib/postgresql/17/demo"
                         }
                      }
                   }
@@ -6292,7 +6290,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/postgresql/16/demo",
+                     "pg1-path=/var/lib/postgresql/17/demo",
                      "",
                      "[global]",
                      "archive-async=y",
@@ -6315,7 +6313,7 @@
                   "option" : {
                      "demo" : {
                         "pg1-path" : {
-                           "value" : "/var/lib/postgresql/16/demo"
+                           "value" : "/var/lib/postgresql/17/demo"
                         }
                      }
                   }
@@ -6324,7 +6322,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/postgresql/16/demo",
+                     "pg1-path=/var/lib/postgresql/17/demo",
                      "recovery-option=primary_conninfo=host=172.17.0.6 port=5432 user=replicator",
                      "",
                      "[global]",
@@ -6348,10 +6346,10 @@
                   "option" : {
                      "demo" : {
                         "pg1-path" : {
-                           "value" : "/var/lib/postgresql/16/demo"
+                           "value" : "/var/lib/postgresql/17/demo"
                         },
                         "pg2-path" : {
-                           "value" : "/var/lib/postgresql/16/demo"
+                           "value" : "/var/lib/postgresql/17/demo"
                         }
                      },
                      "global" : {
@@ -6366,13 +6364,13 @@
                   "config" : [
                      "[demo]",
                      "pg1-host=pg-primary",
-                     "pg1-path=/var/lib/postgresql/16/demo",
+                     "pg1-path=/var/lib/postgresql/17/demo",
                      "pg2-host=pg-standby",
-                     "pg2-path=/var/lib/postgresql/16/demo",
+                     "pg2-path=/var/lib/postgresql/17/demo",
                      "",
                      "[demo-alt]",
                      "pg1-host=pg-alt",
-                     "pg1-path=/var/lib/postgresql/15/demo",
+                     "pg1-path=/var/lib/postgresql/16/demo",
                      "",
                      "[global]",
                      "backup-standby=n",
@@ -6387,8 +6385,8 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo cp /etc/postgresql/15/demo/pg_hba.conf \\",
-                     "    /etc/postgresql/16/demo/pg_hba.conf"
+                     "sudo cp /etc/postgresql/16/demo/pg_hba.conf \\",
+                     "    /etc/postgresql/17/demo/pg_hba.conf"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -6419,7 +6417,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: stanza-upgrade command begin 2.52: --exec-id=2640-2293b514 --log-level-console=info --log-level-file=detail --log-level-stderr=off --no-log-timestamp --no-online --pg1-path=/var/lib/postgresql/16/demo --repo1-host=repository --stanza=demo",
+                     "P00   INFO: stanza-upgrade command begin 2.52: --exec-id=2640-2293b514 --log-level-console=info --log-level-file=detail --log-level-stderr=off --no-log-timestamp --no-online --pg1-path=/var/lib/postgresql/17/demo --repo1-host=repository --stanza=demo",
                      "P00   INFO: stanza-upgrade for stanza 'demo' on repo1",
                      "P00   INFO: stanza-upgrade command end: completed successfully"
                   ]
@@ -6429,7 +6427,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo pg_ctlcluster 16 demo start"
+                     "sudo pg_ctlcluster 17 demo start"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -6442,7 +6440,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo -u postgres pg_lsclusters"
+                     "sudo pg_lsclusters"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -6468,7 +6466,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo pg_dropcluster 15 demo"
+                     "sudo pg_dropcluster 16 demo"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -6481,7 +6479,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo pg_dropcluster 15 demo"
+                     "sudo pg_dropcluster 16 demo"
                   ],
                   "host" : "pg-standby",
                   "load-env" : true,
@@ -6494,7 +6492,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo pg_createcluster 16 demo"
+                     "sudo pg_createcluster 17 demo"
                   ],
                   "host" : "pg-standby",
                   "load-env" : true,
@@ -6550,7 +6548,7 @@
             },
             {
                "key" : {
-                  "file" : "/etc/postgresql/16/demo/postgresql.conf",
+                  "file" : "/etc/postgresql/17/demo/postgresql.conf",
                   "host" : "pg-standby",
                   "option" : {
                      "hot_standby" : {
@@ -6569,7 +6567,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo pg_ctlcluster 16 demo start"
+                     "sudo pg_ctlcluster 17 demo start"
                   ],
                   "host" : "pg-standby",
                   "load-env" : true,
@@ -6621,13 +6619,13 @@
                   "config" : [
                      "[demo]",
                      "pg1-host=pg-primary",
-                     "pg1-path=/var/lib/postgresql/16/demo",
+                     "pg1-path=/var/lib/postgresql/17/demo",
                      "pg2-host=pg-standby",
-                     "pg2-path=/var/lib/postgresql/16/demo",
+                     "pg2-path=/var/lib/postgresql/17/demo",
                      "",
                      "[demo-alt]",
                      "pg1-host=pg-alt",
-                     "pg1-path=/var/lib/postgresql/15/demo",
+                     "pg1-path=/var/lib/postgresql/16/demo",
                      "",
                      "[global]",
                      "backup-standby=y",
@@ -6679,7 +6677,7 @@
                   "id" : "sftp",
                   "image" : "pgbackrest/doc:rhel",
                   "name" : "sftp-server",
-                  "option" : "-m 512m -v /sys/fs/cgroup:/sys/fs/cgroup:rw -v /tmp/$(mktemp -d):/run",
+                  "option" : "-m 512m",
                   "os" : "rhel",
                   "update-hosts" : true
                },
@@ -6745,7 +6743,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo yum install make gcc postgresql12-devel openssl-devel \\",
+                     "sudo yum install make gcc postgresql13-devel openssl-devel \\",
                      "    libxml2-devel lz4-devel libzstd-devel bzip2-devel libyaml-devel libssh2-devel"
                   ],
                   "cmd-extra" : "-y 2>&1",
@@ -6775,7 +6773,7 @@
                   "id" : "pg1",
                   "image" : "pgbackrest/doc:rhel",
                   "name" : "pg-primary",
-                  "option" : "-m 512m -v /sys/fs/cgroup:/sys/fs/cgroup:rw -v /tmp/$(mktemp -d):/run",
+                  "option" : "-m 512m",
                   "os" : "rhel",
                   "update-hosts" : true
                },
@@ -6965,8 +6963,8 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo -u postgres /usr/pgsql-12/bin/initdb \\",
-                     "    -D /var/lib/pgsql/12/data -k -A peer"
+                     "sudo -u postgres /usr/pgsql-13/bin/initdb \\",
+                     "    -D /var/lib/pgsql/13/data -k -A peer"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -6979,7 +6977,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "cat /root/postgresql.common.conf >> /var/lib/pgsql/12/data/postgresql.conf"
+                     "cat /root/postgresql.common.conf >> /var/lib/pgsql/13/data/postgresql.conf"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -6990,7 +6988,7 @@
             },
             {
                "key" : {
-                  "file" : "/var/lib/pgsql/12/data/postgresql.conf",
+                  "file" : "/var/lib/pgsql/13/data/postgresql.conf",
                   "host" : "pg-primary",
                   "option" : {
                      "log_filename" : {
@@ -7012,7 +7010,7 @@
                   "option" : {
                      "demo" : {
                         "pg1-path" : {
-                           "value" : "/var/lib/pgsql/12/data"
+                           "value" : "/var/lib/pgsql/13/data"
                         }
                      },
                      "global" : {
@@ -7029,7 +7027,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/pgsql/12/data"
+                     "pg1-path=/var/lib/pgsql/13/data"
                   ]
                }
             },
@@ -7123,7 +7121,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/pgsql/12/data",
+                     "pg1-path=/var/lib/pgsql/13/data",
                      "",
                      "[global]",
                      "repo1-path=/var/lib/pgbackrest"
@@ -7132,7 +7130,7 @@
             },
             {
                "key" : {
-                  "file" : "/var/lib/pgsql/12/data/postgresql.conf",
+                  "file" : "/var/lib/pgsql/13/data/postgresql.conf",
                   "host" : "pg-primary",
                   "option" : {
                      "archive_command" : {
@@ -7164,7 +7162,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo systemctl restart postgresql-12.service"
+                     "sudo systemctl restart postgresql-13.service"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -7227,7 +7225,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/pgsql/12/data",
+                     "pg1-path=/var/lib/pgsql/13/data",
                      "",
                      "[global]",
                      "repo1-path=/var/lib/pgbackrest",
@@ -7253,7 +7251,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/pgsql/12/data",
+                     "pg1-path=/var/lib/pgsql/13/data",
                      "",
                      "[global]",
                      "repo1-path=/var/lib/pgbackrest",
@@ -7283,7 +7281,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/pgsql/12/data",
+                     "pg1-path=/var/lib/pgsql/13/data",
                      "",
                      "[global]",
                      "repo1-cipher-pass=zWaf6XtpjIVZC5444yXB+cgFDFl7MxGlgkZSaoPvTGirhPygu4jOKOXf9LO4vjfO",
@@ -7317,7 +7315,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: stanza-create command begin 2.52: --exec-id=1124-8550570a --log-level-console=info --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/pgsql/12/data --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --stanza=demo",
+                     "P00   INFO: stanza-create command begin 2.52: --exec-id=1124-8550570a --log-level-console=info --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/pgsql/13/data --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --stanza=demo",
                      "P00   INFO: stanza-create for stanza 'demo' on repo1",
                      "P00   INFO: stanza-create command end: completed successfully"
                   ]
@@ -7344,10 +7342,10 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: check command begin 2.52: --exec-id=1151-49fef788 --log-level-console=info --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/pgsql/12/data --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --stanza=demo",
+                     "P00   INFO: check command begin 2.52: --exec-id=1151-49fef788 --log-level-console=info --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/pgsql/13/data --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --stanza=demo",
                      "P00   INFO: check repo1 configuration (primary)",
                      "P00   INFO: check repo1 archive for WAL (primary)",
-                     "P00   INFO: WAL segment 000000010000000000000001 successfully archived to '/var/lib/pgbackrest/archive/demo/12-1/0000000100000000/000000010000000000000001-572cad774288f7b2182ec728ea7c5c6e57455de3.gz' on repo1",
+                     "P00   INFO: WAL segment 000000010000000000000001 successfully archived to '/var/lib/pgbackrest/archive/demo/13-1/0000000100000000/000000010000000000000001-572cad774288f7b2182ec728ea7c5c6e57455de3.gz' on repo1",
                      "P00   INFO: check command end: completed successfully"
                   ]
                }
@@ -7368,7 +7366,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/pgsql/12/data",
+                     "pg1-path=/var/lib/pgsql/13/data",
                      "",
                      "[global]",
                      "repo1-cipher-pass=zWaf6XtpjIVZC5444yXB+cgFDFl7MxGlgkZSaoPvTGirhPygu4jOKOXf9LO4vjfO",
@@ -7404,7 +7402,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: backup command begin 2.52: --exec-id=1221-435b67be --log-level-console=info --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/pgsql/12/data --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo1-retention-full=2 --stanza=demo --start-fast",
+                     "P00   INFO: backup command begin 2.52: --exec-id=1221-435b67be --log-level-console=info --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/pgsql/13/data --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo1-retention-full=2 --stanza=demo --start-fast",
                      "P00   WARN: no prior backup exists, incr backup has been changed to full",
                      "P00   INFO: execute non-exclusive backup start: backup begins after the requested immediate checkpoint completes",
                      "P00   INFO: backup start archive = 000000010000000000000002, lsn = 0/2000028",
@@ -7492,7 +7490,7 @@
                      "    cipher: aes-256-cbc",
                      "",
                      "    db (current)",
-                     "        wal archive min/max (12): 000000010000000000000001/000000010000000000000005",
+                     "        wal archive min/max (13): 000000010000000000000001/000000010000000000000005",
                      "",
                      "        full backup: 20240527-000426F",
                      "            timestamp start/stop: 2024-05-27 00:04:26+00 / 2024-05-27 00:04:29+00",
@@ -7513,7 +7511,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo systemctl stop postgresql-12.service"
+                     "sudo systemctl stop postgresql-13.service"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -7526,7 +7524,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo -u postgres rm /var/lib/pgsql/12/data/global/pg_control"
+                     "sudo -u postgres rm /var/lib/pgsql/13/data/global/pg_control"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -7539,7 +7537,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo systemctl start postgresql-12.service"
+                     "sudo systemctl start postgresql-13.service"
                   ],
                   "err-expect" : "1",
                   "host" : "pg-primary",
@@ -7553,7 +7551,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo systemctl status postgresql-12.service"
+                     "sudo systemctl status postgresql-13.service"
                   ],
                   "err-expect" : "3",
                   "highlight" : {
@@ -7572,9 +7570,9 @@
                "value" : {
                   "output" : [
                      "       [filtered 12 lines of output]",
-                     "May 27 00:04:33 pg-primary systemd[1]: postgresql-12.service: Main process exited, code=exited, status=2/INVALIDARGUMENT",
-                     "May 27 00:04:33 pg-primary systemd[1]: postgresql-12.service: Failed with result 'exit-code'.",
-                     "May 27 00:04:33 pg-primary systemd[1]: Failed to start PostgreSQL 12 database server."
+                     "May 27 00:04:33 pg-primary systemd[1]: postgresql-13.service: Main process exited, code=exited, status=2/INVALIDARGUMENT",
+                     "May 27 00:04:33 pg-primary systemd[1]: postgresql-13.service: Failed with result 'exit-code'.",
+                     "May 27 00:04:33 pg-primary systemd[1]: Failed to start PostgreSQL 13 database server."
                   ]
                }
             },
@@ -7582,7 +7580,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo -u postgres find /var/lib/pgsql/12/data -mindepth 1 -delete"
+                     "sudo -u postgres find /var/lib/pgsql/13/data -mindepth 1 -delete"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -7608,7 +7606,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo systemctl start postgresql-12.service"
+                     "sudo systemctl start postgresql-13.service"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -7792,7 +7790,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/pgsql/12/data",
+                     "pg1-path=/var/lib/pgsql/13/data",
                      "",
                      "[global]",
                      "repo1-bundle=y",
@@ -7854,7 +7852,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/pgsql/12/data",
+                     "pg1-path=/var/lib/pgsql/13/data",
                      "",
                      "[global]",
                      "repo1-block=y",
@@ -7928,7 +7926,7 @@
                      "    cipher: aes-256-cbc",
                      "",
                      "    db (current)",
-                     "        wal archive min/max (12): 000000020000000000000007/000000020000000000000009",
+                     "        wal archive min/max (13): 000000020000000000000007/000000020000000000000009",
                      "",
                      "        full backup: 20240527-000443F",
                      "            timestamp start/stop: 2024-05-27 00:04:43+00 / 2024-05-27 00:04:46+00",
@@ -7983,7 +7981,7 @@
                      "    cipher: aes-256-cbc",
                      "",
                      "    db (current)",
-                     "        wal archive min/max (12): 000000020000000000000007/000000020000000000000009",
+                     "        wal archive min/max (13): 000000020000000000000007/000000020000000000000009",
                      "",
                      "        full backup: 20240527-000443F",
                      "            timestamp start/stop: 2024-05-27 00:04:43+00 / 2024-05-27 00:04:46+00",
@@ -8014,7 +8012,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/pgsql/12/data",
+                     "pg1-path=/var/lib/pgsql/13/data",
                      "",
                      "[global]",
                      "repo1-block=y",
@@ -8054,8 +8052,8 @@
                   "output" : [
                      "       [filtered 993 lines of output]",
                      "P00   INFO: repo1: remove expired backup 20240527-000439F",
-                     "P00 DETAIL: repo1: 12-1 archive retention on backup 20240527-000443F, start = 000000020000000000000008",
-                     "P00   INFO: repo1: 12-1 remove archive, start = 000000020000000000000007, stop = 000000020000000000000007",
+                     "P00 DETAIL: repo1: 13-1 archive retention on backup 20240527-000443F, start = 000000020000000000000008",
+                     "P00   INFO: repo1: 13-1 remove archive, start = 000000020000000000000007, stop = 000000020000000000000007",
                      "P00   INFO: expire command end: completed successfully"
                   ]
                }
@@ -8103,7 +8101,7 @@
                      "       [filtered 11 lines of output]",
                      "P00   INFO: repo1: expire full backup 20240527-000443F",
                      "P00   INFO: repo1: remove expired backup 20240527-000443F",
-                     "P00   INFO: repo1: 12-1 remove archive, start = 000000020000000000000008, stop = 000000020000000000000009",
+                     "P00   INFO: repo1: 13-1 remove archive, start = 000000020000000000000008, stop = 000000020000000000000009",
                      "P00   INFO: expire command end: completed successfully"
                   ]
                }
@@ -8124,7 +8122,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/pgsql/12/data",
+                     "pg1-path=/var/lib/pgsql/13/data",
                      "",
                      "[global]",
                      "repo1-block=y",
@@ -8233,7 +8231,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/pgsql/12/data",
+                     "pg1-path=/var/lib/pgsql/13/data",
                      "",
                      "[global]",
                      "repo1-block=y",
@@ -8356,13 +8354,13 @@
                "value" : {
                   "output" : [
                      "P00   INFO: expire command begin 2.52: --exec-id=2477-16c1b80f --log-level-console=detail --log-level-stderr=off --no-log-timestamp --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo1-retention-archive=1 --repo1-retention-archive-type=diff --repo1-retention-diff=2 --repo1-retention-full=2 --stanza=demo",
-                     "P00 DETAIL: repo1: 12-1 archive retention on backup 20240527-000448F, start = 00000002000000000000000A, stop = 00000002000000000000000B",
-                     "P00 DETAIL: repo1: 12-1 archive retention on backup 20240527-000451F, start = 00000002000000000000000D, stop = 00000002000000000000000D",
-                     "P00 DETAIL: repo1: 12-1 archive retention on backup 20240527-000451F_20240527-000459D, start = 000000020000000000000012, stop = 000000020000000000000013",
-                     "P00 DETAIL: repo1: 12-1 archive retention on backup 20240527-000451F_20240527-000502D, start = 000000020000000000000016",
-                     "P00   INFO: repo1: 12-1 remove archive, start = 00000002000000000000000C, stop = 00000002000000000000000C",
-                     "P00   INFO: repo1: 12-1 remove archive, start = 00000002000000000000000E, stop = 000000020000000000000011",
-                     "P00   INFO: repo1: 12-1 remove archive, start = 000000020000000000000014, stop = 000000020000000000000015",
+                     "P00 DETAIL: repo1: 13-1 archive retention on backup 20240527-000448F, start = 00000002000000000000000A, stop = 00000002000000000000000B",
+                     "P00 DETAIL: repo1: 13-1 archive retention on backup 20240527-000451F, start = 00000002000000000000000D, stop = 00000002000000000000000D",
+                     "P00 DETAIL: repo1: 13-1 archive retention on backup 20240527-000451F_20240527-000459D, start = 000000020000000000000012, stop = 000000020000000000000013",
+                     "P00 DETAIL: repo1: 13-1 archive retention on backup 20240527-000451F_20240527-000502D, start = 000000020000000000000016",
+                     "P00   INFO: repo1: 13-1 remove archive, start = 00000002000000000000000C, stop = 00000002000000000000000C",
+                     "P00   INFO: repo1: 13-1 remove archive, start = 00000002000000000000000E, stop = 000000020000000000000011",
+                     "P00   INFO: repo1: 13-1 remove archive, start = 000000020000000000000014, stop = 000000020000000000000015",
                      "P00   INFO: expire command end: completed successfully"
                   ]
                }
@@ -8371,7 +8369,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo systemctl stop postgresql-12.service"
+                     "sudo systemctl stop postgresql-13.service"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -8403,11 +8401,11 @@
                "value" : {
                   "output" : [
                      "       [filtered 2 lines of output]",
-                     "P00 DETAIL: check '/var/lib/pgsql/12/data' exists",
+                     "P00 DETAIL: check '/var/lib/pgsql/13/data' exists",
                      "P00 DETAIL: remove 'global/pg_control' so cluster will not start if restore does not complete",
-                     "P00   INFO: remove invalid files/links/paths from '/var/lib/pgsql/12/data'",
-                     "P00 DETAIL: remove invalid file '/var/lib/pgsql/12/data/backup_label.old'",
-                     "P00 DETAIL: remove invalid file '/var/lib/pgsql/12/data/base/13396/pg_internal.init'",
+                     "P00   INFO: remove invalid files/links/paths from '/var/lib/pgsql/13/data'",
+                     "P00 DETAIL: remove invalid file '/var/lib/pgsql/13/data/backup_label.old'",
+                     "P00 DETAIL: remove invalid file '/var/lib/pgsql/13/data/base/13396/pg_internal.init'",
                      "       [filtered 1027 lines of output]"
                   ]
                }
@@ -8416,7 +8414,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo systemctl start postgresql-12.service"
+                     "sudo systemctl start postgresql-13.service"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -8547,7 +8545,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo -u postgres du -sh /var/lib/pgsql/12/data/base/32768"
+                     "sudo -u postgres du -sh /var/lib/pgsql/13/data/base/32768"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -8557,7 +8555,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "7.8M\t/var/lib/pgsql/12/data/base/32768"
+                     "7.8M\t/var/lib/pgsql/13/data/base/32768"
                   ]
                }
             },
@@ -8612,7 +8610,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo systemctl stop postgresql-12.service"
+                     "sudo systemctl stop postgresql-13.service"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -8639,7 +8637,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo systemctl start postgresql-12.service"
+                     "sudo systemctl start postgresql-13.service"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -8712,7 +8710,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo -u postgres du -sh /var/lib/pgsql/12/data/base/32768"
+                     "sudo -u postgres du -sh /var/lib/pgsql/13/data/base/32768"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -8722,7 +8720,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "16K\t/var/lib/pgsql/12/data/base/32768"
+                     "16K\t/var/lib/pgsql/13/data/base/32768"
                   ]
                }
             },
@@ -8948,7 +8946,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo systemctl stop postgresql-12.service"
+                     "sudo systemctl stop postgresql-13.service"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -8976,7 +8974,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo rm /var/lib/pgsql/12/data/log/postgresql.log"
+                     "sudo rm /var/lib/pgsql/13/data/log/postgresql.log"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -8989,7 +8987,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo systemctl start postgresql-12.service"
+                     "sudo systemctl start postgresql-13.service"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -9043,7 +9041,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo -u postgres cat /var/lib/pgsql/12/data/log/postgresql.log"
+                     "sudo -u postgres cat /var/lib/pgsql/13/data/log/postgresql.log"
                   ],
                   "highlight" : {
                      "filter" : true,
@@ -9076,7 +9074,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo systemctl stop postgresql-12.service"
+                     "sudo systemctl stop postgresql-13.service"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -9104,7 +9102,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo rm /var/lib/pgsql/12/data/log/postgresql.log"
+                     "sudo rm /var/lib/pgsql/13/data/log/postgresql.log"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -9117,7 +9115,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo -u postgres cat /var/lib/pgsql/12/data/postgresql.auto.conf"
+                     "sudo -u postgres cat /var/lib/pgsql/13/data/postgresql.auto.conf"
                   ],
                   "highlight" : {
                      "filter" : true,
@@ -9146,7 +9144,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo systemctl start postgresql-12.service"
+                     "sudo systemctl start postgresql-13.service"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -9200,7 +9198,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo -u postgres cat /var/lib/pgsql/12/data/log/postgresql.log"
+                     "sudo -u postgres cat /var/lib/pgsql/13/data/log/postgresql.log"
                   ],
                   "highlight" : {
                      "filter" : true,
@@ -9239,7 +9237,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo systemctl stop postgresql-12.service"
+                     "sudo systemctl stop postgresql-13.service"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -9296,7 +9294,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: stanza-delete command begin 2.52: --exec-id=3855-f55f9527 --log-level-console=info --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/pgsql/12/data --repo=1 --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --stanza=demo",
+                     "P00   INFO: stanza-delete command begin 2.52: --exec-id=3855-f55f9527 --log-level-console=info --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/pgsql/13/data --repo=1 --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --stanza=demo",
                      "P00   INFO: stanza-delete command end: completed successfully"
                   ]
                }
@@ -9305,7 +9303,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo systemctl start postgresql-12.service"
+                     "sudo systemctl start postgresql-13.service"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -9348,7 +9346,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/pgsql/12/data",
+                     "pg1-path=/var/lib/pgsql/13/data",
                      "",
                      "[global]",
                      "process-max=4",
@@ -9419,7 +9417,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: stanza-create command begin 2.52: --exec-id=4012-28156641 --log-level-console=info --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/pgsql/12/data --repo2-azure-account=<redacted> --repo2-azure-container=demo-container --repo2-azure-key=<redacted> --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo2-path=/demo-repo --repo2-type=azure --stanza=demo",
+                     "P00   INFO: stanza-create command begin 2.52: --exec-id=4012-28156641 --log-level-console=info --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/pgsql/13/data --repo2-azure-account=<redacted> --repo2-azure-container=demo-container --repo2-azure-key=<redacted> --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo2-path=/demo-repo --repo2-type=azure --stanza=demo",
                      "P00   INFO: stanza-create for stanza 'demo' on repo1",
                      "P00   INFO: stanza-create for stanza 'demo' on repo2",
                      "P00   INFO: stanza-create command end: completed successfully"
@@ -9448,7 +9446,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: backup command begin 2.52: --exec-id=4039-4e5dfd95 --log-level-console=info --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/pgsql/12/data --process-max=4 --repo=2 --repo2-azure-account=<redacted> --repo2-azure-container=demo-container --repo2-azure-key=<redacted> --repo1-block --repo1-bundle --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo2-path=/demo-repo --repo1-retention-diff=2 --repo1-retention-full=2 --repo2-retention-full=4 --repo2-type=azure --stanza=demo --start-fast",
+                     "P00   INFO: backup command begin 2.52: --exec-id=4039-4e5dfd95 --log-level-console=info --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/pgsql/13/data --process-max=4 --repo=2 --repo2-azure-account=<redacted> --repo2-azure-container=demo-container --repo2-azure-key=<redacted> --repo1-block --repo1-bundle --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo2-path=/demo-repo --repo1-retention-diff=2 --repo1-retention-full=2 --repo2-retention-full=4 --repo2-type=azure --stanza=demo --start-fast",
                      "P00   WARN: no prior backup exists, incr backup has been changed to full",
                      "P00   INFO: execute non-exclusive backup start: backup begins after the requested immediate checkpoint completes",
                      "P00   INFO: backup start archive = 00000006000000000000001B, lsn = 0/1B000028",
@@ -9501,7 +9499,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/pgsql/12/data",
+                     "pg1-path=/var/lib/pgsql/13/data",
                      "",
                      "[global]",
                      "process-max=4",
@@ -9609,7 +9607,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: backup command begin 2.52: --exec-id=4192-26574a45 --log-level-console=info --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/pgsql/12/data --process-max=4 --repo=3 --repo2-azure-account=<redacted> --repo2-azure-container=demo-container --repo2-azure-key=<redacted> --repo1-block --repo1-bundle --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo2-path=/demo-repo --repo3-path=/demo-repo --repo1-retention-diff=2 --repo1-retention-full=2 --repo2-retention-full=4 --repo3-retention-full=4 --repo3-s3-bucket=demo-bucket --repo3-s3-endpoint=s3.us-east-1.amazonaws.com --repo3-s3-key=<redacted> --repo3-s3-key-secret=<redacted> --repo3-s3-region=us-east-1 --repo2-type=azure --repo3-type=s3 --stanza=demo --start-fast",
+                     "P00   INFO: backup command begin 2.52: --exec-id=4192-26574a45 --log-level-console=info --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/pgsql/13/data --process-max=4 --repo=3 --repo2-azure-account=<redacted> --repo2-azure-container=demo-container --repo2-azure-key=<redacted> --repo1-block --repo1-bundle --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo2-path=/demo-repo --repo3-path=/demo-repo --repo1-retention-diff=2 --repo1-retention-full=2 --repo2-retention-full=4 --repo3-retention-full=4 --repo3-s3-bucket=demo-bucket --repo3-s3-endpoint=s3.us-east-1.amazonaws.com --repo3-s3-key=<redacted> --repo3-s3-key-secret=<redacted> --repo3-s3-region=us-east-1 --repo2-type=azure --repo3-type=s3 --stanza=demo --start-fast",
                      "P00   WARN: no prior backup exists, incr backup has been changed to full",
                      "P00   INFO: execute non-exclusive backup start: backup begins after the requested immediate checkpoint completes",
                      "P00   INFO: backup start archive = 00000006000000000000001C, lsn = 0/1C000028",
@@ -9662,7 +9660,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/pgsql/12/data",
+                     "pg1-path=/var/lib/pgsql/13/data",
                      "",
                      "[global]",
                      "process-max=4",
@@ -9845,7 +9843,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: backup command begin 2.52: --exec-id=4409-07025786 --log-level-console=info --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/pgsql/12/data --process-max=4 --repo=4 --repo2-azure-account=<redacted> --repo2-azure-container=demo-container --repo2-azure-key=<redacted> --repo1-block --repo1-bundle --repo4-bundle --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo2-path=/demo-repo --repo3-path=/demo-repo --repo4-path=/demo-repo --repo1-retention-diff=2 --repo1-retention-full=2 --repo2-retention-full=4 --repo3-retention-full=4 --repo3-s3-bucket=demo-bucket --repo3-s3-endpoint=s3.us-east-1.amazonaws.com --repo3-s3-key=<redacted> --repo3-s3-key-secret=<redacted> --repo3-s3-region=us-east-1 --repo4-sftp-host=sftp-server --repo4-sftp-host-key-hash-type=sha1 --repo4-sftp-host-user=pgbackrest --repo4-sftp-private-key-file=/var/lib/pgsql/.ssh/id_rsa_sftp --repo4-sftp-public-key-file=/var/lib/pgsql/.ssh/id_rsa_sftp.pub --repo2-type=azure --repo3-type=s3 --repo4-type=sftp --stanza=demo --start-fast",
+                     "P00   INFO: backup command begin 2.52: --exec-id=4409-07025786 --log-level-console=info --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/pgsql/13/data --process-max=4 --repo=4 --repo2-azure-account=<redacted> --repo2-azure-container=demo-container --repo2-azure-key=<redacted> --repo1-block --repo1-bundle --repo4-bundle --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo2-path=/demo-repo --repo3-path=/demo-repo --repo4-path=/demo-repo --repo1-retention-diff=2 --repo1-retention-full=2 --repo2-retention-full=4 --repo3-retention-full=4 --repo3-s3-bucket=demo-bucket --repo3-s3-endpoint=s3.us-east-1.amazonaws.com --repo3-s3-key=<redacted> --repo3-s3-key-secret=<redacted> --repo3-s3-region=us-east-1 --repo4-sftp-host=sftp-server --repo4-sftp-host-key-hash-type=sha1 --repo4-sftp-host-user=pgbackrest --repo4-sftp-private-key-file=/var/lib/pgsql/.ssh/id_rsa_sftp --repo4-sftp-public-key-file=/var/lib/pgsql/.ssh/id_rsa_sftp.pub --repo2-type=azure --repo3-type=s3 --repo4-type=sftp --stanza=demo --start-fast",
                      "P00   WARN: option 'repo4-retention-full' is not set for 'repo4-retention-full-type=count', the repository may run out of space",
                      "            HINT: to retain full backups indefinitely (without warning), set option 'repo4-retention-full' to the maximum.",
                      "P00   WARN: no prior backup exists, incr backup has been changed to full",
@@ -9889,7 +9887,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/pgsql/12/data",
+                     "pg1-path=/var/lib/pgsql/13/data",
                      "",
                      "[global]",
                      "process-max=4",
@@ -9938,7 +9936,7 @@
                   "id" : "repo1",
                   "image" : "pgbackrest/doc:rhel",
                   "name" : "repository",
-                  "option" : "-m 512m -v /sys/fs/cgroup:/sys/fs/cgroup:rw -v /tmp/$(mktemp -d):/run",
+                  "option" : "-m 512m",
                   "os" : "rhel",
                   "update-hosts" : true
                },
@@ -10186,7 +10184,7 @@
                            "value" : "tls"
                         },
                         "pg1-path" : {
-                           "value" : "/var/lib/pgsql/12/data"
+                           "value" : "/var/lib/pgsql/13/data"
                         }
                      },
                      "global" : {
@@ -10229,7 +10227,7 @@
                      "pg1-host-cert-file=/etc/pgbackrest/cert/client.crt",
                      "pg1-host-key-file=/etc/pgbackrest/cert/client.key",
                      "pg1-host-type=tls",
-                     "pg1-path=/var/lib/pgsql/12/data",
+                     "pg1-path=/var/lib/pgsql/13/data",
                      "",
                      "[global]",
                      "repo1-path=/var/lib/pgbackrest",
@@ -10250,7 +10248,7 @@
                   "option" : {
                      "demo" : {
                         "pg1-path" : {
-                           "value" : "/var/lib/pgsql/12/data"
+                           "value" : "/var/lib/pgsql/13/data"
                         }
                      },
                      "global" : {
@@ -10301,7 +10299,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/pgsql/12/data",
+                     "pg1-path=/var/lib/pgsql/13/data",
                      "",
                      "[global]",
                      "log-level-file=detail",
@@ -10629,7 +10627,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo systemctl stop postgresql-12.service"
+                     "sudo systemctl stop postgresql-13.service"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -10655,7 +10653,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo systemctl start postgresql-12.service"
+                     "sudo systemctl start postgresql-13.service"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -10711,7 +10709,7 @@
                      "pg1-host-cert-file=/etc/pgbackrest/cert/client.crt",
                      "pg1-host-key-file=/etc/pgbackrest/cert/client.key",
                      "pg1-host-type=tls",
-                     "pg1-path=/var/lib/pgsql/12/data",
+                     "pg1-path=/var/lib/pgsql/13/data",
                      "",
                      "[global]",
                      "process-max=3",
@@ -10765,7 +10763,7 @@
                      "    cipher: none",
                      "",
                      "    db (current)",
-                     "        wal archive min/max (12): 000000070000000000000025/000000070000000000000027",
+                     "        wal archive min/max (13): 000000070000000000000025/000000070000000000000027",
                      "",
                      "        full backup: 20240527-000652F",
                      "            timestamp start/stop: 2024-05-27 00:06:52+00 / 2024-05-27 00:06:56+00",
@@ -10912,7 +10910,7 @@
                   "id" : "pg2",
                   "image" : "pgbackrest/doc:rhel",
                   "name" : "pg-standby",
-                  "option" : "-m 512m -v /sys/fs/cgroup:/sys/fs/cgroup:rw -v /tmp/$(mktemp -d):/run",
+                  "option" : "-m 512m",
                   "os" : "rhel",
                   "update-hosts" : true
                },
@@ -11060,7 +11058,7 @@
                   "option" : {
                      "demo" : {
                         "pg1-path" : {
-                           "value" : "/var/lib/pgsql/12/data"
+                           "value" : "/var/lib/pgsql/13/data"
                         }
                      },
                      "global" : {
@@ -11110,7 +11108,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/pgsql/12/data",
+                     "pg1-path=/var/lib/pgsql/13/data",
                      "",
                      "[global]",
                      "log-level-file=detail",
@@ -11256,7 +11254,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo -u postgres mkdir -p -m 700 /var/lib/pgsql/12/data"
+                     "sudo -u postgres mkdir -p -m 700 /var/lib/pgsql/13/data"
                   ],
                   "host" : "pg-standby",
                   "load-env" : true,
@@ -11282,7 +11280,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo -u postgres cat /var/lib/pgsql/12/data/postgresql.auto.conf"
+                     "sudo -u postgres cat /var/lib/pgsql/13/data/postgresql.auto.conf"
                   ],
                   "host" : "pg-standby",
                   "load-env" : true,
@@ -11318,7 +11316,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "cat /root/postgresql.common.conf >> /var/lib/pgsql/12/data/postgresql.conf"
+                     "cat /root/postgresql.common.conf >> /var/lib/pgsql/13/data/postgresql.conf"
                   ],
                   "host" : "pg-standby",
                   "load-env" : true,
@@ -11329,7 +11327,7 @@
             },
             {
                "key" : {
-                  "file" : "/var/lib/pgsql/12/data/postgresql.conf",
+                  "file" : "/var/lib/pgsql/13/data/postgresql.conf",
                   "host" : "pg-standby",
                   "option" : {
                      "archive_command" : {
@@ -11368,7 +11366,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo rm /var/lib/pgsql/12/data/log/postgresql.log"
+                     "sudo rm /var/lib/pgsql/13/data/log/postgresql.log"
                   ],
                   "host" : "pg-standby",
                   "load-env" : true,
@@ -11381,7 +11379,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo systemctl start postgresql-12.service"
+                     "sudo systemctl start postgresql-13.service"
                   ],
                   "host" : "pg-standby",
                   "load-env" : true,
@@ -11407,7 +11405,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo -u postgres cat /var/lib/pgsql/12/data/log/postgresql.log"
+                     "sudo -u postgres cat /var/lib/pgsql/13/data/log/postgresql.log"
                   ],
                   "highlight" : {
                      "filter" : true,
@@ -11567,7 +11565,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: check command begin 2.52: --exec-id=1292-2e4caa2c --log-level-console=info --log-level-file=detail --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/pgsql/12/data --repo1-host=repository --repo1-host-ca-file=/etc/pgbackrest/cert/ca.crt --repo1-host-cert-file=/etc/pgbackrest/cert/client.crt --repo1-host-key-file=/etc/pgbackrest/cert/client.key --repo1-host-type=tls --stanza=demo",
+                     "P00   INFO: check command begin 2.52: --exec-id=1292-2e4caa2c --log-level-console=info --log-level-file=detail --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/pgsql/13/data --repo1-host=repository --repo1-host-ca-file=/etc/pgbackrest/cert/ca.crt --repo1-host-cert-file=/etc/pgbackrest/cert/client.crt --repo1-host-key-file=/etc/pgbackrest/cert/client.key --repo1-host-type=tls --stanza=demo",
                      "P00   INFO: check repo1 (standby)",
                      "P00   INFO: switch wal not performed because this is a standby",
                      "P00   INFO: check command end: completed successfully"
@@ -11599,7 +11597,7 @@
                   "cmd" : [
                      "sudo -u postgres sh -c 'echo \\",
                      "    \"host    replication     replicator      172.17.0.8/32           md5\" \\",
-                     "    >> /var/lib/pgsql/12/data/pg_hba.conf'"
+                     "    >> /var/lib/pgsql/13/data/pg_hba.conf'"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -11612,7 +11610,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo systemctl reload postgresql-12.service"
+                     "sudo systemctl reload postgresql-13.service"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -11637,7 +11635,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/pgsql/12/data",
+                     "pg1-path=/var/lib/pgsql/13/data",
                      "recovery-option=primary_conninfo=host=172.17.0.6 port=5432 user=replicator",
                      "",
                      "[global]",
@@ -11687,7 +11685,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo systemctl stop postgresql-12.service"
+                     "sudo systemctl stop postgresql-13.service"
                   ],
                   "host" : "pg-standby",
                   "load-env" : true,
@@ -11713,7 +11711,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo -u postgres cat /var/lib/pgsql/12/data/postgresql.auto.conf"
+                     "sudo -u postgres cat /var/lib/pgsql/13/data/postgresql.auto.conf"
                   ],
                   "host" : "pg-standby",
                   "load-env" : true,
@@ -11748,7 +11746,7 @@
             },
             {
                "key" : {
-                  "file" : "/var/lib/pgsql/12/data/postgresql.conf",
+                  "file" : "/var/lib/pgsql/13/data/postgresql.conf",
                   "host" : "pg-standby",
                   "option" : {
                      "hot_standby" : {
@@ -11772,7 +11770,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo rm /var/lib/pgsql/12/data/log/postgresql.log"
+                     "sudo rm /var/lib/pgsql/13/data/log/postgresql.log"
                   ],
                   "host" : "pg-standby",
                   "load-env" : true,
@@ -11785,7 +11783,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo systemctl start postgresql-12.service"
+                     "sudo systemctl start postgresql-13.service"
                   ],
                   "host" : "pg-standby",
                   "load-env" : true,
@@ -11811,7 +11809,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo -u postgres cat /var/lib/pgsql/12/data/log/postgresql.log"
+                     "sudo -u postgres cat /var/lib/pgsql/13/data/log/postgresql.log"
                   ],
                   "highlight" : {
                      "filter" : true,
@@ -11902,7 +11900,7 @@
                   "id" : "pgalt",
                   "image" : "pgbackrest/doc:rhel",
                   "name" : "pg-alt",
-                  "option" : "-m 512m -v /sys/fs/cgroup:/sys/fs/cgroup:rw -v /tmp/$(mktemp -d):/run",
+                  "option" : "-m 512m",
                   "os" : "rhel",
                   "update-hosts" : true
                },
@@ -12050,7 +12048,7 @@
                   "option" : {
                      "demo-alt" : {
                         "pg1-path" : {
-                           "value" : "/var/lib/pgsql/12/data"
+                           "value" : "/var/lib/pgsql/13/data"
                         }
                      },
                      "global" : {
@@ -12100,7 +12098,7 @@
                "value" : {
                   "config" : [
                      "[demo-alt]",
-                     "pg1-path=/var/lib/pgsql/12/data",
+                     "pg1-path=/var/lib/pgsql/13/data",
                      "",
                      "[global]",
                      "log-level-file=detail",
@@ -12139,7 +12137,7 @@
                            "value" : "tls"
                         },
                         "pg1-path" : {
-                           "value" : "/var/lib/pgsql/12/data"
+                           "value" : "/var/lib/pgsql/13/data"
                         }
                      }
                   }
@@ -12153,7 +12151,7 @@
                      "pg1-host-cert-file=/etc/pgbackrest/cert/client.crt",
                      "pg1-host-key-file=/etc/pgbackrest/cert/client.key",
                      "pg1-host-type=tls",
-                     "pg1-path=/var/lib/pgsql/12/data",
+                     "pg1-path=/var/lib/pgsql/13/data",
                      "",
                      "[demo-alt]",
                      "pg1-host=pg-alt",
@@ -12161,7 +12159,7 @@
                      "pg1-host-cert-file=/etc/pgbackrest/cert/client.crt",
                      "pg1-host-key-file=/etc/pgbackrest/cert/client.key",
                      "pg1-host-type=tls",
-                     "pg1-path=/var/lib/pgsql/12/data",
+                     "pg1-path=/var/lib/pgsql/13/data",
                      "",
                      "[global]",
                      "process-max=3",
@@ -12305,8 +12303,8 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo -u postgres /usr/pgsql-12/bin/initdb \\",
-                     "    -D /var/lib/pgsql/12/data -k -A peer"
+                     "sudo -u postgres /usr/pgsql-13/bin/initdb \\",
+                     "    -D /var/lib/pgsql/13/data -k -A peer"
                   ],
                   "host" : "pg-alt",
                   "load-env" : true,
@@ -12319,7 +12317,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "cat /root/postgresql.common.conf >> /var/lib/pgsql/12/data/postgresql.conf"
+                     "cat /root/postgresql.common.conf >> /var/lib/pgsql/13/data/postgresql.conf"
                   ],
                   "host" : "pg-alt",
                   "load-env" : true,
@@ -12330,7 +12328,7 @@
             },
             {
                "key" : {
-                  "file" : "/var/lib/pgsql/12/data/postgresql.conf",
+                  "file" : "/var/lib/pgsql/13/data/postgresql.conf",
                   "host" : "pg-alt",
                   "option" : {
                      "archive_command" : {
@@ -12365,7 +12363,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo systemctl restart postgresql-12.service"
+                     "sudo systemctl restart postgresql-13.service"
                   ],
                   "host" : "pg-alt",
                   "load-env" : true,
@@ -12408,7 +12406,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: stanza-create command begin 2.52: --exec-id=947-bbc659e4 --log-level-console=info --log-level-file=detail --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/pgsql/12/data --repo1-host=repository --repo1-host-ca-file=/etc/pgbackrest/cert/ca.crt --repo1-host-cert-file=/etc/pgbackrest/cert/client.crt --repo1-host-key-file=/etc/pgbackrest/cert/client.key --repo1-host-type=tls --stanza=demo-alt",
+                     "P00   INFO: stanza-create command begin 2.52: --exec-id=947-bbc659e4 --log-level-console=info --log-level-file=detail --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/pgsql/13/data --repo1-host=repository --repo1-host-ca-file=/etc/pgbackrest/cert/ca.crt --repo1-host-cert-file=/etc/pgbackrest/cert/client.crt --repo1-host-key-file=/etc/pgbackrest/cert/client.key --repo1-host-type=tls --stanza=demo-alt",
                      "P00   INFO: stanza-create for stanza 'demo-alt' on repo1",
                      "P00   INFO: stanza-create command end: completed successfully"
                   ]
@@ -12439,7 +12437,7 @@
                      "P00   INFO: check stanza 'demo-alt'",
                      "P00   INFO: check repo1 configuration (primary)",
                      "P00   INFO: check repo1 archive for WAL (primary)",
-                     "P00   INFO: WAL segment 000000010000000000000001 successfully archived to '/var/lib/pgbackrest/archive/demo-alt/12-1/0000000100000000/000000010000000000000001-63cc8bdb98eee57682d0af5b16314d599c3e3b6c.gz' on repo1",
+                     "P00   INFO: WAL segment 000000010000000000000001 successfully archived to '/var/lib/pgbackrest/archive/demo-alt/13-1/0000000100000000/000000010000000000000001-63cc8bdb98eee57682d0af5b16314d599c3e3b6c.gz' on repo1",
                      "P00   INFO: check command end: completed successfully"
                   ]
                }
@@ -12469,11 +12467,11 @@
                      "P00   INFO: check stanza 'demo'",
                      "P00   INFO: check repo1 configuration (primary)",
                      "P00   INFO: check repo1 archive for WAL (primary)",
-                     "P00   INFO: WAL segment 000000070000000000000029 successfully archived to '/var/lib/pgbackrest/archive/demo/12-1/0000000700000000/000000070000000000000029-87916bee751ebfc4345c6404ea495bc996a3071e.gz' on repo1",
+                     "P00   INFO: WAL segment 000000070000000000000029 successfully archived to '/var/lib/pgbackrest/archive/demo/13-1/0000000700000000/000000070000000000000029-87916bee751ebfc4345c6404ea495bc996a3071e.gz' on repo1",
                      "P00   INFO: check stanza 'demo-alt'",
                      "P00   INFO: check repo1 configuration (primary)",
                      "P00   INFO: check repo1 archive for WAL (primary)",
-                     "P00   INFO: WAL segment 000000010000000000000002 successfully archived to '/var/lib/pgbackrest/archive/demo-alt/12-1/0000000100000000/000000010000000000000002-dda9d7f6aafd916afaf72ddc5b978421d0ca63a3.gz' on repo1",
+                     "P00   INFO: WAL segment 000000010000000000000002 successfully archived to '/var/lib/pgbackrest/archive/demo-alt/13-1/0000000100000000/000000010000000000000002-dda9d7f6aafd916afaf72ddc5b978421d0ca63a3.gz' on repo1",
                      "P00   INFO: check command end: completed successfully"
                   ]
                }
@@ -12559,7 +12557,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/pgsql/12/data",
+                     "pg1-path=/var/lib/pgsql/13/data",
                      "",
                      "[global]",
                      "archive-async=y",
@@ -12613,7 +12611,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/pgsql/12/data",
+                     "pg1-path=/var/lib/pgsql/13/data",
                      "recovery-option=primary_conninfo=host=172.17.0.6 port=5432 user=replicator",
                      "",
                      "[global]",
@@ -12661,7 +12659,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo systemctl restart postgresql-12.service"
+                     "sudo systemctl restart postgresql-13.service"
                   ],
                   "host" : "pg-standby",
                   "load-env" : true,
@@ -12722,10 +12720,10 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: check command begin 2.52: --exec-id=5437-0e128737 --log-level-console=info --log-level-file=detail --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/pgsql/12/data --repo1-host=repository --repo1-host-ca-file=/etc/pgbackrest/cert/ca.crt --repo1-host-cert-file=/etc/pgbackrest/cert/client.crt --repo1-host-key-file=/etc/pgbackrest/cert/client.key --repo1-host-type=tls --stanza=demo",
+                     "P00   INFO: check command begin 2.52: --exec-id=5437-0e128737 --log-level-console=info --log-level-file=detail --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/pgsql/13/data --repo1-host=repository --repo1-host-ca-file=/etc/pgbackrest/cert/ca.crt --repo1-host-cert-file=/etc/pgbackrest/cert/client.crt --repo1-host-key-file=/etc/pgbackrest/cert/client.key --repo1-host-type=tls --stanza=demo",
                      "P00   INFO: check repo1 configuration (primary)",
                      "P00   INFO: check repo1 archive for WAL (primary)",
-                     "P00   INFO: WAL segment 00000007000000000000002F successfully archived to '/var/lib/pgbackrest/archive/demo/12-1/0000000700000000/00000007000000000000002F-82a3e0ac18a0e3007bf6caff91610582bc650bde.gz' on repo1",
+                     "P00   INFO: WAL segment 00000007000000000000002F successfully archived to '/var/lib/pgbackrest/archive/demo/13-1/0000000700000000/00000007000000000000002F-82a3e0ac18a0e3007bf6caff91610582bc650bde.gz' on repo1",
                      "P00   INFO: check command end: completed successfully"
                   ]
                }
@@ -12752,14 +12750,14 @@
                "value" : {
                   "output" : [
                      "-------------------PROCESS START-------------------",
-                     "P00   INFO: archive-push:async command begin 2.52: [/var/lib/pgsql/12/data/pg_wal] --archive-async --exec-id=5405-3e8356d1 --log-level-console=off --log-level-file=detail --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/pgsql/12/data --process-max=2 --repo1-host=repository --repo1-host-ca-file=/etc/pgbackrest/cert/ca.crt --repo1-host-cert-file=/etc/pgbackrest/cert/client.crt --repo1-host-key-file=/etc/pgbackrest/cert/client.key --repo1-host-type=tls --spool-path=/var/spool/pgbackrest --stanza=demo",
+                     "P00   INFO: archive-push:async command begin 2.52: [/var/lib/pgsql/13/data/pg_wal] --archive-async --exec-id=5405-3e8356d1 --log-level-console=off --log-level-file=detail --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/pgsql/13/data --process-max=2 --repo1-host=repository --repo1-host-ca-file=/etc/pgbackrest/cert/ca.crt --repo1-host-cert-file=/etc/pgbackrest/cert/client.crt --repo1-host-key-file=/etc/pgbackrest/cert/client.key --repo1-host-type=tls --spool-path=/var/spool/pgbackrest --stanza=demo",
                      "P00   INFO: push 1 WAL file(s) to archive: 00000007000000000000002A",
                      "P01 DETAIL: pushed WAL file '00000007000000000000002A' to the archive",
                      "P00 DETAIL: statistics: {\"socket.client\":{\"total\":1},\"socket.session\":{\"total\":1},\"tls.client\":{\"total\":1},\"tls.session\":{\"total\":1}}",
                      "P00   INFO: archive-push:async command end: completed successfully",
                      "",
                      "-------------------PROCESS START-------------------",
-                     "P00   INFO: archive-push:async command begin 2.52: [/var/lib/pgsql/12/data/pg_wal] --archive-async --exec-id=5439-e355211d --log-level-console=off --log-level-file=detail --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/pgsql/12/data --process-max=2 --repo1-host=repository --repo1-host-ca-file=/etc/pgbackrest/cert/ca.crt --repo1-host-cert-file=/etc/pgbackrest/cert/client.crt --repo1-host-key-file=/etc/pgbackrest/cert/client.key --repo1-host-type=tls --spool-path=/var/spool/pgbackrest --stanza=demo",
+                     "P00   INFO: archive-push:async command begin 2.52: [/var/lib/pgsql/13/data/pg_wal] --archive-async --exec-id=5439-e355211d --log-level-console=off --log-level-file=detail --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/pgsql/13/data --process-max=2 --repo1-host=repository --repo1-host-ca-file=/etc/pgbackrest/cert/ca.crt --repo1-host-cert-file=/etc/pgbackrest/cert/client.crt --repo1-host-key-file=/etc/pgbackrest/cert/client.key --repo1-host-type=tls --spool-path=/var/spool/pgbackrest --stanza=demo",
                      "P00   INFO: push 4 WAL file(s) to archive: 00000007000000000000002B...00000007000000000000002E",
                      "P01 DETAIL: pushed WAL file '00000007000000000000002B' to the archive",
                      "P02 DETAIL: pushed WAL file '00000007000000000000002C' to the archive",
@@ -12769,7 +12767,7 @@
                      "P00   INFO: archive-push:async command end: completed successfully",
                      "",
                      "-------------------PROCESS START-------------------",
-                     "P00   INFO: archive-push:async command begin 2.52: [/var/lib/pgsql/12/data/pg_wal] --archive-async --exec-id=5447-842eac4b --log-level-console=off --log-level-file=detail --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/pgsql/12/data --process-max=2 --repo1-host=repository --repo1-host-ca-file=/etc/pgbackrest/cert/ca.crt --repo1-host-cert-file=/etc/pgbackrest/cert/client.crt --repo1-host-key-file=/etc/pgbackrest/cert/client.key --repo1-host-type=tls --spool-path=/var/spool/pgbackrest --stanza=demo",
+                     "P00   INFO: archive-push:async command begin 2.52: [/var/lib/pgsql/13/data/pg_wal] --archive-async --exec-id=5447-842eac4b --log-level-console=off --log-level-file=detail --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/pgsql/13/data --process-max=2 --repo1-host=repository --repo1-host-ca-file=/etc/pgbackrest/cert/ca.crt --repo1-host-cert-file=/etc/pgbackrest/cert/client.crt --repo1-host-key-file=/etc/pgbackrest/cert/client.key --repo1-host-type=tls --spool-path=/var/spool/pgbackrest --stanza=demo",
                      "P00   INFO: push 1 WAL file(s) to archive: 00000007000000000000002F",
                      "P01 DETAIL: pushed WAL file '00000007000000000000002F' to the archive",
                      "P00 DETAIL: statistics: {\"socket.client\":{\"total\":1},\"socket.session\":{\"total\":1},\"tls.client\":{\"total\":1},\"tls.session\":{\"total\":1}}",
@@ -12812,23 +12810,23 @@
                "value" : {
                   "output" : [
                      "-------------------PROCESS START-------------------",
-                     "P00   INFO: archive-get:async command begin 2.52: [000000070000000000000026, 000000070000000000000027, 000000070000000000000028, 000000070000000000000029, 00000007000000000000002A, 00000007000000000000002B, 00000007000000000000002C, 00000007000000000000002D] --archive-async --exec-id=1829-41e8ea4b --log-level-console=off --log-level-file=detail --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/pgsql/12/data --process-max=2 --repo1-host=repository --repo1-host-ca-file=/etc/pgbackrest/cert/ca.crt --repo1-host-cert-file=/etc/pgbackrest/cert/client.crt --repo1-host-key-file=/etc/pgbackrest/cert/client.key --repo1-host-type=tls --spool-path=/var/spool/pgbackrest --stanza=demo",
+                     "P00   INFO: archive-get:async command begin 2.52: [000000070000000000000026, 000000070000000000000027, 000000070000000000000028, 000000070000000000000029, 00000007000000000000002A, 00000007000000000000002B, 00000007000000000000002C, 00000007000000000000002D] --archive-async --exec-id=1829-41e8ea4b --log-level-console=off --log-level-file=detail --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/pgsql/13/data --process-max=2 --repo1-host=repository --repo1-host-ca-file=/etc/pgbackrest/cert/ca.crt --repo1-host-cert-file=/etc/pgbackrest/cert/client.crt --repo1-host-key-file=/etc/pgbackrest/cert/client.key --repo1-host-type=tls --spool-path=/var/spool/pgbackrest --stanza=demo",
                      "P00   INFO: get 8 WAL file(s) from archive: 000000070000000000000026...00000007000000000000002D",
-                     "P01 DETAIL: found 000000070000000000000026 in the repo1: 12-1 archive",
-                     "P02 DETAIL: found 000000070000000000000027 in the repo1: 12-1 archive",
-                     "P01 DETAIL: found 000000070000000000000028 in the repo1: 12-1 archive",
-                     "P02 DETAIL: found 000000070000000000000029 in the repo1: 12-1 archive",
+                     "P01 DETAIL: found 000000070000000000000026 in the repo1: 13-1 archive",
+                     "P02 DETAIL: found 000000070000000000000027 in the repo1: 13-1 archive",
+                     "P01 DETAIL: found 000000070000000000000028 in the repo1: 13-1 archive",
+                     "P02 DETAIL: found 000000070000000000000029 in the repo1: 13-1 archive",
                      "P00 DETAIL: unable to find 00000007000000000000002A in the archive",
                      "P00 DETAIL: statistics: {\"socket.client\":{\"total\":1},\"socket.session\":{\"total\":1},\"tls.client\":{\"total\":1},\"tls.session\":{\"total\":1}}",
                      "       [filtered 17 lines of output]",
-                     "P00   INFO: archive-get:async command begin 2.52: [00000007000000000000002A, 00000007000000000000002B, 00000007000000000000002C, 00000007000000000000002D, 00000007000000000000002E, 00000007000000000000002F, 000000070000000000000030, 000000070000000000000031] --archive-async --exec-id=1883-c072908e --log-level-console=off --log-level-file=detail --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/pgsql/12/data --process-max=2 --repo1-host=repository --repo1-host-ca-file=/etc/pgbackrest/cert/ca.crt --repo1-host-cert-file=/etc/pgbackrest/cert/client.crt --repo1-host-key-file=/etc/pgbackrest/cert/client.key --repo1-host-type=tls --spool-path=/var/spool/pgbackrest --stanza=demo",
+                     "P00   INFO: archive-get:async command begin 2.52: [00000007000000000000002A, 00000007000000000000002B, 00000007000000000000002C, 00000007000000000000002D, 00000007000000000000002E, 00000007000000000000002F, 000000070000000000000030, 000000070000000000000031] --archive-async --exec-id=1883-c072908e --log-level-console=off --log-level-file=detail --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/pgsql/13/data --process-max=2 --repo1-host=repository --repo1-host-ca-file=/etc/pgbackrest/cert/ca.crt --repo1-host-cert-file=/etc/pgbackrest/cert/client.crt --repo1-host-key-file=/etc/pgbackrest/cert/client.key --repo1-host-type=tls --spool-path=/var/spool/pgbackrest --stanza=demo",
                      "P00   INFO: get 8 WAL file(s) from archive: 00000007000000000000002A...000000070000000000000031",
-                     "P01 DETAIL: found 00000007000000000000002A in the repo1: 12-1 archive",
-                     "P02 DETAIL: found 00000007000000000000002B in the repo1: 12-1 archive",
-                     "P01 DETAIL: found 00000007000000000000002C in the repo1: 12-1 archive",
-                     "P02 DETAIL: found 00000007000000000000002D in the repo1: 12-1 archive",
-                     "P01 DETAIL: found 00000007000000000000002E in the repo1: 12-1 archive",
-                     "P02 DETAIL: found 00000007000000000000002F in the repo1: 12-1 archive",
+                     "P01 DETAIL: found 00000007000000000000002A in the repo1: 13-1 archive",
+                     "P02 DETAIL: found 00000007000000000000002B in the repo1: 13-1 archive",
+                     "P01 DETAIL: found 00000007000000000000002C in the repo1: 13-1 archive",
+                     "P02 DETAIL: found 00000007000000000000002D in the repo1: 13-1 archive",
+                     "P01 DETAIL: found 00000007000000000000002E in the repo1: 13-1 archive",
+                     "P02 DETAIL: found 00000007000000000000002F in the repo1: 13-1 archive",
                      "P00 DETAIL: unable to find 000000070000000000000030 in the archive",
                      "P00 DETAIL: statistics: {\"socket.client\":{\"total\":1},\"socket.session\":{\"total\":1},\"tls.client\":{\"total\":1},\"tls.session\":{\"total\":1}}",
                      "       [filtered 14 lines of output]"
@@ -12875,7 +12873,7 @@
                            "value" : "tls"
                         },
                         "pg2-path" : {
-                           "value" : "/var/lib/pgsql/12/data"
+                           "value" : "/var/lib/pgsql/13/data"
                         }
                      },
                      "global" : {
@@ -12894,13 +12892,13 @@
                      "pg1-host-cert-file=/etc/pgbackrest/cert/client.crt",
                      "pg1-host-key-file=/etc/pgbackrest/cert/client.key",
                      "pg1-host-type=tls",
-                     "pg1-path=/var/lib/pgsql/12/data",
+                     "pg1-path=/var/lib/pgsql/13/data",
                      "pg2-host=pg-standby",
                      "pg2-host-ca-file=/etc/pgbackrest/cert/ca.crt",
                      "pg2-host-cert-file=/etc/pgbackrest/cert/client.crt",
                      "pg2-host-key-file=/etc/pgbackrest/cert/client.key",
                      "pg2-host-type=tls",
-                     "pg2-path=/var/lib/pgsql/12/data",
+                     "pg2-path=/var/lib/pgsql/13/data",
                      "",
                      "[demo-alt]",
                      "pg1-host=pg-alt",
@@ -12908,7 +12906,7 @@
                      "pg1-host-cert-file=/etc/pgbackrest/cert/client.crt",
                      "pg1-host-key-file=/etc/pgbackrest/cert/client.key",
                      "pg1-host-type=tls",
-                     "pg1-path=/var/lib/pgsql/12/data",
+                     "pg1-path=/var/lib/pgsql/13/data",
                      "",
                      "[global]",
                      "backup-standby=y",
@@ -12951,14 +12949,14 @@
                      "P00   INFO: wait for replay on the standby to reach 0/31000028",
                      "P00   INFO: replay on the standby reached 0/31000028",
                      "P00   INFO: check archive for prior segment 000000070000000000000030",
-                     "P01 DETAIL: backup file pg-primary:/var/lib/pgsql/12/data/global/pg_control (8KB, 0.34%) checksum 1c7efd19cbf84de2f410b4151d52bf31e19f1645",
-                     "P02 DETAIL: backup file pg-standby:/var/lib/pgsql/12/data/base/13396/2608 (456KB, 19.77%) checksum fdf79152d7ad43993fd0e95f3ab99230b5456da9",
-                     "P03 DETAIL: backup file pg-standby:/var/lib/pgsql/12/data/base/13396/1249 (440KB, 38.52%) checksum 80fa69c6255667377f0514d4931db96c0d023b6c",
-                     "P04 DETAIL: backup file pg-standby:/var/lib/pgsql/12/data/base/13396/2674 (344KB, 53.18%) checksum 82b8cc51aae38a0a0b387a92a9bb094029a58456",
-                     "P01 DETAIL: backup file pg-primary:/var/lib/pgsql/12/data/log/postgresql.log (6.1KB, 53.44%) checksum 9d278e8c055faca201c744359fa6e0b5764088b8",
-                     "P01 DETAIL: backup file pg-primary:/var/lib/pgsql/12/data/pg_hba.conf (4.5KB, 53.63%) checksum 65e54ae24bda87b2542351cb16a7fecc7e5aceeb",
-                     "P01 DETAIL: match file from prior backup pg-primary:/var/lib/pgsql/12/data/current_logfiles (26B, 53.63%) checksum 78a9f5c10960f0d91fcd313937469824861795a2",
-                     "P01 DETAIL: match file from prior backup pg-primary:/var/lib/pgsql/12/data/pg_logical/replorigin_checkpoint (8B, 53.63%) checksum 347fc8f2df71bd4436e38bd1516ccd7ea0d46532",
+                     "P01 DETAIL: backup file pg-primary:/var/lib/pgsql/13/data/global/pg_control (8KB, 0.34%) checksum 1c7efd19cbf84de2f410b4151d52bf31e19f1645",
+                     "P02 DETAIL: backup file pg-standby:/var/lib/pgsql/13/data/base/13396/2608 (456KB, 19.77%) checksum fdf79152d7ad43993fd0e95f3ab99230b5456da9",
+                     "P03 DETAIL: backup file pg-standby:/var/lib/pgsql/13/data/base/13396/1249 (440KB, 38.52%) checksum 80fa69c6255667377f0514d4931db96c0d023b6c",
+                     "P04 DETAIL: backup file pg-standby:/var/lib/pgsql/13/data/base/13396/2674 (344KB, 53.18%) checksum 82b8cc51aae38a0a0b387a92a9bb094029a58456",
+                     "P01 DETAIL: backup file pg-primary:/var/lib/pgsql/13/data/log/postgresql.log (6.1KB, 53.44%) checksum 9d278e8c055faca201c744359fa6e0b5764088b8",
+                     "P01 DETAIL: backup file pg-primary:/var/lib/pgsql/13/data/pg_hba.conf (4.5KB, 53.63%) checksum 65e54ae24bda87b2542351cb16a7fecc7e5aceeb",
+                     "P01 DETAIL: match file from prior backup pg-primary:/var/lib/pgsql/13/data/current_logfiles (26B, 53.63%) checksum 78a9f5c10960f0d91fcd313937469824861795a2",
+                     "P01 DETAIL: match file from prior backup pg-primary:/var/lib/pgsql/13/data/pg_logical/replorigin_checkpoint (8B, 53.63%) checksum 347fc8f2df71bd4436e38bd1516ccd7ea0d46532",
                      "       [filtered 1298 lines of output]"
                   ]
                }
@@ -12967,7 +12965,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo systemctl stop postgresql-12.service"
+                     "sudo systemctl stop postgresql-13.service"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -12980,7 +12978,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo systemctl stop postgresql-12.service"
+                     "sudo systemctl stop postgresql-13.service"
                   ],
                   "host" : "pg-standby",
                   "load-env" : true,
@@ -12993,8 +12991,8 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo -u postgres /usr/pgsql-13/bin/initdb \\",
-                     "    -D /var/lib/pgsql/13/data -k -A peer"
+                     "sudo -u postgres /usr/pgsql-14/bin/initdb \\",
+                     "    -D /var/lib/pgsql/14/data -k -A peer"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -13008,13 +13006,13 @@
                   "bash-wrap" : true,
                   "cmd" : [
                      "sudo -u postgres sh -c 'cd /var/lib/pgsql && \\",
-                     "    /usr/pgsql-13/bin/pg_upgrade \\",
-                     "    --old-bindir=/usr/pgsql-12/bin \\",
-                     "    --new-bindir=/usr/pgsql-13/bin \\",
-                     "    --old-datadir=/var/lib/pgsql/12/data \\",
-                     "    --new-datadir=/var/lib/pgsql/13/data \\",
-                     "    --old-options=\" -c config_file=/var/lib/pgsql/12/data/postgresql.conf\" \\",
-                     "    --new-options=\" -c config_file=/var/lib/pgsql/13/data/postgresql.conf\"'"
+                     "    /usr/pgsql-14/bin/pg_upgrade \\",
+                     "    --old-bindir=/usr/pgsql-13/bin \\",
+                     "    --new-bindir=/usr/pgsql-14/bin \\",
+                     "    --old-datadir=/var/lib/pgsql/13/data \\",
+                     "    --new-datadir=/var/lib/pgsql/14/data \\",
+                     "    --old-options=\" -c config_file=/var/lib/pgsql/13/data/postgresql.conf\" \\",
+                     "    --new-options=\" -c config_file=/var/lib/pgsql/14/data/postgresql.conf\"'"
                   ],
                   "highlight" : {
                      "filter" : true,
@@ -13045,7 +13043,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "cat /root/postgresql.common.conf >> /var/lib/pgsql/13/data/postgresql.conf"
+                     "cat /root/postgresql.common.conf >> /var/lib/pgsql/14/data/postgresql.conf"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -13056,7 +13054,7 @@
             },
             {
                "key" : {
-                  "file" : "/var/lib/pgsql/13/data/postgresql.conf",
+                  "file" : "/var/lib/pgsql/14/data/postgresql.conf",
                   "host" : "pg-primary",
                   "option" : {
                      "archive_command" : {
@@ -13094,7 +13092,7 @@
                   "option" : {
                      "demo" : {
                         "pg1-path" : {
-                           "value" : "/var/lib/pgsql/13/data"
+                           "value" : "/var/lib/pgsql/14/data"
                         }
                      }
                   }
@@ -13103,7 +13101,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/pgsql/13/data",
+                     "pg1-path=/var/lib/pgsql/14/data",
                      "",
                      "[global]",
                      "archive-async=y",
@@ -13135,7 +13133,7 @@
                   "option" : {
                      "demo" : {
                         "pg1-path" : {
-                           "value" : "/var/lib/pgsql/13/data"
+                           "value" : "/var/lib/pgsql/14/data"
                         }
                      }
                   }
@@ -13144,7 +13142,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/pgsql/13/data",
+                     "pg1-path=/var/lib/pgsql/14/data",
                      "recovery-option=primary_conninfo=host=172.17.0.6 port=5432 user=replicator",
                      "",
                      "[global]",
@@ -13177,10 +13175,10 @@
                   "option" : {
                      "demo" : {
                         "pg1-path" : {
-                           "value" : "/var/lib/pgsql/13/data"
+                           "value" : "/var/lib/pgsql/14/data"
                         },
                         "pg2-path" : {
-                           "value" : "/var/lib/pgsql/13/data"
+                           "value" : "/var/lib/pgsql/14/data"
                         }
                      },
                      "global" : {
@@ -13199,13 +13197,13 @@
                      "pg1-host-cert-file=/etc/pgbackrest/cert/client.crt",
                      "pg1-host-key-file=/etc/pgbackrest/cert/client.key",
                      "pg1-host-type=tls",
-                     "pg1-path=/var/lib/pgsql/13/data",
+                     "pg1-path=/var/lib/pgsql/14/data",
                      "pg2-host=pg-standby",
                      "pg2-host-ca-file=/etc/pgbackrest/cert/ca.crt",
                      "pg2-host-cert-file=/etc/pgbackrest/cert/client.crt",
                      "pg2-host-key-file=/etc/pgbackrest/cert/client.key",
                      "pg2-host-type=tls",
-                     "pg2-path=/var/lib/pgsql/13/data",
+                     "pg2-path=/var/lib/pgsql/14/data",
                      "",
                      "[demo-alt]",
                      "pg1-host=pg-alt",
@@ -13213,7 +13211,7 @@
                      "pg1-host-cert-file=/etc/pgbackrest/cert/client.crt",
                      "pg1-host-key-file=/etc/pgbackrest/cert/client.key",
                      "pg1-host-type=tls",
-                     "pg1-path=/var/lib/pgsql/12/data",
+                     "pg1-path=/var/lib/pgsql/13/data",
                      "",
                      "[global]",
                      "backup-standby=n",
@@ -13233,8 +13231,8 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo cp /var/lib/pgsql/12/data/pg_hba.conf \\",
-                     "    /var/lib/pgsql/13/data/pg_hba.conf"
+                     "sudo cp /var/lib/pgsql/13/data/pg_hba.conf \\",
+                     "    /var/lib/pgsql/14/data/pg_hba.conf"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -13265,7 +13263,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: stanza-upgrade command begin 2.52: --exec-id=5938-72f20868 --log-level-console=info --log-level-file=detail --log-level-stderr=off --no-log-timestamp --no-online --pg1-path=/var/lib/pgsql/13/data --repo1-host=repository --repo1-host-ca-file=/etc/pgbackrest/cert/ca.crt --repo1-host-cert-file=/etc/pgbackrest/cert/client.crt --repo1-host-key-file=/etc/pgbackrest/cert/client.key --repo1-host-type=tls --stanza=demo",
+                     "P00   INFO: stanza-upgrade command begin 2.52: --exec-id=5938-72f20868 --log-level-console=info --log-level-file=detail --log-level-stderr=off --no-log-timestamp --no-online --pg1-path=/var/lib/pgsql/14/data --repo1-host=repository --repo1-host-ca-file=/etc/pgbackrest/cert/ca.crt --repo1-host-cert-file=/etc/pgbackrest/cert/client.crt --repo1-host-key-file=/etc/pgbackrest/cert/client.key --repo1-host-type=tls --stanza=demo",
                      "P00   INFO: stanza-upgrade for stanza 'demo' on repo1",
                      "P00   INFO: stanza-upgrade command end: completed successfully"
                   ]
@@ -13275,7 +13273,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo systemctl start postgresql-13.service"
+                     "sudo systemctl start postgresql-14.service"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -13288,7 +13286,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo -u postgres systemctl status postgresql-13.service"
+                     "sudo -u postgres systemctl status postgresql-14.service"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -13314,7 +13312,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo rm -rf /var/lib/pgsql/12/data"
+                     "sudo rm -rf /var/lib/pgsql/13/data"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -13327,7 +13325,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo rm -rf /var/lib/pgsql/12/data"
+                     "sudo rm -rf /var/lib/pgsql/13/data"
                   ],
                   "host" : "pg-standby",
                   "load-env" : true,
@@ -13340,7 +13338,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo -u postgres mkdir -p -m 700 /usr/pgsql-13/bin"
+                     "sudo -u postgres mkdir -p -m 700 /usr/pgsql-14/bin"
                   ],
                   "host" : "pg-standby",
                   "load-env" : true,
@@ -13397,7 +13395,7 @@
             },
             {
                "key" : {
-                  "file" : "/var/lib/pgsql/13/data/postgresql.conf",
+                  "file" : "/var/lib/pgsql/14/data/postgresql.conf",
                   "host" : "pg-standby",
                   "option" : {
                      "hot_standby" : {
@@ -13416,7 +13414,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo systemctl start postgresql-13.service"
+                     "sudo systemctl start postgresql-14.service"
                   ],
                   "host" : "pg-standby",
                   "load-env" : true,
@@ -13472,13 +13470,13 @@
                      "pg1-host-cert-file=/etc/pgbackrest/cert/client.crt",
                      "pg1-host-key-file=/etc/pgbackrest/cert/client.key",
                      "pg1-host-type=tls",
-                     "pg1-path=/var/lib/pgsql/13/data",
+                     "pg1-path=/var/lib/pgsql/14/data",
                      "pg2-host=pg-standby",
                      "pg2-host-ca-file=/etc/pgbackrest/cert/ca.crt",
                      "pg2-host-cert-file=/etc/pgbackrest/cert/client.crt",
                      "pg2-host-key-file=/etc/pgbackrest/cert/client.key",
                      "pg2-host-type=tls",
-                     "pg2-path=/var/lib/pgsql/13/data",
+                     "pg2-path=/var/lib/pgsql/14/data",
                      "",
                      "[demo-alt]",
                      "pg1-host=pg-alt",
@@ -13486,7 +13484,7 @@
                      "pg1-host-cert-file=/etc/pgbackrest/cert/client.crt",
                      "pg1-host-key-file=/etc/pgbackrest/cert/client.key",
                      "pg1-host-type=tls",
-                     "pg1-path=/var/lib/pgsql/12/data",
+                     "pg1-path=/var/lib/pgsql/13/data",
                      "",
                      "[global]",
                      "backup-standby=y",

--- a/doc/xml/user-guide.xml
+++ b/doc/xml/user-guide.xml
@@ -14,8 +14,8 @@
         <variable key="os-rhel-title">RHEL</variable>
 
         <!-- Base PostgreSQL versions -->
-        <variable key="os-debian-pg-version">15</variable>
-        <variable key="os-rhel-pg-version">12</variable>
+        <variable key="os-debian-pg-version">16</variable>
+        <variable key="os-rhel-pg-version">13</variable>
 
         <!-- User-defined package to use in documentation (use "apt" to install the current PGDG apt package) -->
         <variable key="package">none</variable>
@@ -70,8 +70,8 @@
 
         <variable key="pg-version-nodot" eval="y">my $version = '{[pg-version]}'; $version =~ s/\.//g; return $version;</variable>
 
-        <variable key="pg-version-upgrade" if="{[os-type-is-debian]}">16</variable>
-        <variable key="pg-version-upgrade" if="{[os-type-is-rhel]}">13</variable>
+        <variable key="pg-version-upgrade" if="{[os-type-is-debian]}">17</variable>
+        <variable key="pg-version-upgrade" if="{[os-type-is-rhel]}">14</variable>
         <variable key="pg-version-upgrade-nodot" eval="y">my $version = '{[pg-version-upgrade]}'; $version =~ s/\.//g; return $version;</variable>
 
         <variable key="pg-bin-path" if="{[os-type-is-debian]}">/usr/lib/postgresql/{[pg-version]}/bin</variable>

--- a/doc/xml/user-guide.xml
+++ b/doc/xml/user-guide.xml
@@ -170,8 +170,6 @@
         <!-- Hosts -->
         <variable key="host-image">pgbackrest/doc:{[os-type]}</variable>
 
-        <variable key="host-option">-v /sys/fs/cgroup:/sys/fs/cgroup:rw -v /tmp/$(mktemp -d):/run</variable>
-
         <!-- Limit host memory to check for memory leaks. Some environments do not allow memory to be set so allow disabling. -->
         <variable key="host-mem-limit">y</variable>
         <variable key="host-mem" if="'{[host-mem-limit]}' eq 'y'">-m 512m</variable>
@@ -357,20 +355,7 @@
     </host-define>
 
     <host-define if="{[os-type-is-rhel]}" image="{[host-image]}" from="{[os-image]}">
-        ENV container docker
-
         {[copy-ca-cert]}
-
-        RUN mkdir -p /lib/systemd/system/sysinit.target.wants &amp;&amp; \
-            (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == \
-            systemd-tmpfiles-setup.service ] || rm -f $i; done); \
-            rm -f /lib/systemd/system/multi-user.target.wants/*;\
-            rm -f /etc/systemd/system/*.wants/*;\
-            rm -f /lib/systemd/system/local-fs.target.wants/*; \
-            rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
-            rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
-            rm -f /lib/systemd/system/basic.target.wants/*;\
-            rm -f /lib/systemd/system/anaconda.target.wants/*;
 
         VOLUME [ "/sys/fs/cgroup" ]
 
@@ -402,6 +387,19 @@
         # Install PostgreSQL
         RUN yum install -y postgresql{[pg-version-nodot]}-server postgresql{[pg-version-upgrade-nodot]}-server
 
+        # Install Azure CLI
+        RUN rpm --import https://packages.microsoft.com/keys/microsoft.asc
+        RUN dnf install -y https://packages.microsoft.com/config/rhel/8/packages-microsoft-prod.rpm
+        RUN dnf install -y azure-cli
+
+        # Install systemctl replacement that works without systemd running
+        ENV SYSCTL_REP_VER=1.5.8066
+        RUN wget -q -O - https://github.com/gdraheim/docker-systemctl-replacement/archive/refs/tags/v${SYSCTL_REP_VER?}.tar.gz | \
+            tar zx -C /root
+        RUN rm -f /usr/bin/systemctl
+        RUN cp /root/docker-systemctl-replacement-${SYSCTL_REP_VER?}/files/docker/systemctl3.py /usr/bin/systemctl
+        RUN rm -rf /root/docker-systemctl-replacement-${SYSCTL_REP_VER?}
+
         # Create an ssh key for root so all hosts can ssh to each other as root
         RUN \ {[ssh-key-install]}
 
@@ -412,14 +410,6 @@
         RUN adduser -n {[host-user]} &amp;&amp; \
             echo '{[host-user]}        ALL=(ALL)       NOPASSWD: ALL' > /etc/sudoers.d/{[host-user]}
 
-        # Enable the user session service so logons are allowed
-        RUN echo "[Install]" >> /usr/lib/systemd/system/systemd-user-sessions.service &amp;&amp; \
-            echo "[WantedBy=default.target]" >> /usr/lib/systemd/system/systemd-user-sessions.service &amp;&amp; \
-            systemctl enable systemd-user-sessions.service &amp;&amp; \
-            mkdir -p /etc/systemd/system/default.target.wants &amp;&amp; \
-            ln -s /usr/lib/systemd/system/systemd-user-sessions.service \
-                /etc/systemd/system/default.target.wants/systemd-user-sessions.service
-
         # Set locale
         RUN echo en_US.UTF-8 UTF-8 > /etc/locale.conf
 
@@ -427,7 +417,7 @@
         ENV PATH=/usr/pgsql-{[pg-version]}/bin:$PATH
         ENV PKG_CONFIG_PATH=/usr/pgsql-{[pg-version]}/lib/pkgconfig:$PKG_CONFIG_PATH
 
-        CMD ["/usr/sbin/init"]
+        ENTRYPOINT rm -rf /run/nologin &amp;&amp; /usr/sbin/sshd -D
     </host-define>
 
     <!-- ======================================================================================================================= -->
@@ -898,7 +888,7 @@
         <host-add if="'{[s3-local]}' eq 'y'" id="{[host-s3-id]}" name="{[host-s3]}" user="root" image="{[s3-image]}" os="{[os-type]}" option="-v {[fake-cert-path]}/s3-server.crt:/root/.minio/certs/public.crt:ro -v {[fake-cert-path]}/s3-server.key:/root/.minio/certs/private.key:ro -e MINIO_REGION={[s3-region]} -e MINIO_DOMAIN={[s3-endpoint]} -e MINIO_BROWSER=off -e MINIO_ACCESS_KEY={[s3-key]} -e MINIO_SECRET_KEY={[s3-key-secret]}" param="server /data --address :443" update-hosts="n"/>
 
         <!-- Create SFTP server first to allow it time to boot before being used -->
-        <host-add id="{[host-sftp-id]}" name="{[host-sftp]}" user="{[host-sftp-user]}" image="{[host-sftp-image]}" os="{[os-type]}" mount="{[host-sftp-mount]}" option="{[host-mem]} {[host-option]}"/>
+        <host-add id="{[host-sftp-id]}" name="{[host-sftp]}" user="{[host-sftp-user]}" image="{[host-sftp-image]}" os="{[os-type]}" mount="{[host-sftp-mount]}"/>
 
         <p>This user guide is intended to be followed sequentially from beginning to end &amp;mdash; each section depends on the last. For example, the <link section="/restore">Restore</link> section relies on setup that is performed in the <link section="/quickstart">Quick Start</link> section. Once <backrest/> is up and running then skipping around is possible but following the user guide in order is recommended the first time through.</p>
 
@@ -998,7 +988,7 @@
 
         <p>Installing <backrest/> from a package is preferable to building from source. See <link section="/installation">Installation</link> for more information about packages.</p>
 
-        <host-add id="{[host-build-id]}" name="{[host-build]}" user="{[host-build-user]}" image="{[host-build-image]}" os="{[os-type]}" mount="{[host-build-mount]}" option="{[host-option]}"/>
+        <host-add id="{[host-build-id]}" name="{[host-build]}" user="{[host-build-user]}" image="{[host-build-image]}" os="{[os-type]}" mount="{[host-build-mount]}"/>
 
         <p>When building from source it is best to use a build host rather than building on production. Many of the tools required for the build should generally not be installed in production. <backrest/> consists of a single executable so it is easy to copy to a new host once it is built.</p>
 
@@ -1085,7 +1075,7 @@
 
         <p>A new host named <host>{[host-pg1]}</host> is created to contain the demo cluster and run <backrest/> examples.</p>
 
-        <host-add id="{[host-pg1-id]}" name="{[host-pg1]}" user="{[host-pg1-user]}" image="{[host-pg1-image]}" os="{[os-type]}" mount="{[host-pg1-mount]}" option="{[host-mem]} {[host-option]}"/>
+        <host-add id="{[host-pg1-id]}" name="{[host-pg1]}" user="{[host-pg1-user]}" image="{[host-pg1-image]}" os="{[os-type]}" mount="{[host-pg1-mount]}" option="{[host-mem]}"/>
 
         <!-- <execute-list if="{[pg-version]} >= 11" host="{[host-pg1]}">
             <title>Create <user>{[br-user]}</user> user</title>
@@ -1540,7 +1530,7 @@
 
                 <execute if="{[os-type-is-rhel]}" user="root" output="y" err-expect="3">
                     <exe-cmd>{[pg-cluster-check]}</exe-cmd>
-                    <exe-highlight>Failed to start PostgreSQL</exe-highlight>
+                    <exe-highlight>failed</exe-highlight>
                 </execute>
             </execute-list>
 
@@ -2608,7 +2598,7 @@
 
             <admonition type="note">The <backrest/> version installed on the <host>repository</host> host must exactly match the version installed on the <postgres/> host.</admonition>
 
-            <host-add id="{[host-repo1-id]}" name="{[host-repo1]}" user="{[host-repo1-user]}" image="{[host-repo1-image]}" os="{[os-type]}" mount="{[host-repo1-mount]}" option="{[host-mem]} {[host-option]}"/>
+            <host-add id="{[host-repo1-id]}" name="{[host-repo1]}" user="{[host-repo1-user]}" image="{[host-repo1-image]}" os="{[os-type]}" mount="{[host-repo1-mount]}" option="{[host-mem]}"/>
 
             <p>The <user>{[br-user]}</user> user is created to own the <backrest/> repository. Any user can own the repository but it is best not to use <user>postgres</user> (if it exists) to avoid confusion.</p>
 
@@ -3035,7 +3025,7 @@
 
             <p>A new host named <host>{[host-pg2]}</host> is created to run the standby.</p>
 
-            <host-add id="{[host-pg2-id]}" name="{[host-pg2]}" user="{[host-pg2-user]}" image="{[host-pg2-image]}" os="{[os-type]}" mount="{[host-pg2-mount]}" option="{[host-mem]} {[host-option]}"/>
+            <host-add id="{[host-pg2-id]}" name="{[host-pg2]}" user="{[host-pg2-user]}" image="{[host-pg2-image]}" os="{[os-type]}" mount="{[host-pg2-mount]}" option="{[host-mem]}"/>
 
             <!-- <execute-list if="{[pg-version]} >= 11" host="{[host-pg2]}">
                 <title>Create <user>{[br-user]}</user> user</title>
@@ -3428,7 +3418,7 @@
 
             <p>A new host named <host>{[host-pgalt]}</host> is created to run the new primary.</p>
 
-            <host-add id="{[host-pgalt-id]}" name="{[host-pgalt]}" user="{[host-pgalt-user]}" image="{[host-pgalt-image]}" os="{[os-type]}" mount="{[host-pgalt-mount]}" option="{[host-mem]} {[host-option]}"/>
+            <host-add id="{[host-pgalt-id]}" name="{[host-pgalt]}" user="{[host-pgalt-user]}" image="{[host-pgalt-image]}" os="{[os-type]}" mount="{[host-pgalt-mount]}" option="{[host-mem]}"/>
 
             <block id="br-install">
                 <block-variable-replace key="br-install-host">{[host-pgalt]}</block-variable-replace>
@@ -4235,7 +4225,7 @@
         <execute-list host="{[host-pg1]}">
             <title>Check configuration</title>
 
-            <execute user="postgres" output="n" filter="n">
+            <execute user="root" output="n" filter="n">
                 <exe-cmd>{[pg-cluster-check-upgrade]}</exe-cmd>
             </execute>
 

--- a/test/lib/pgBackRestTest/Common/VmTest.pm
+++ b/test/lib/pgBackRestTest/Common/VmTest.pm
@@ -159,9 +159,9 @@ my $oyVm =
 
         &VM_DB_TEST =>
         [
-            PG_VERSION_12,
             PG_VERSION_14,
             PG_VERSION_15,
+            PG_VERSION_16,
         ],
     },
 
@@ -218,8 +218,8 @@ my $oyVm =
         &VM_DB_TEST =>
         [
             PG_VERSION_94,
+            PG_VERSION_95,
             PG_VERSION_96,
-            PG_VERSION_10,
         ],
     },
 
@@ -251,9 +251,9 @@ my $oyVm =
 
         &VM_DB_TEST =>
         [
-            PG_VERSION_95,
+            PG_VERSION_10,
             PG_VERSION_11,
-            PG_VERSION_16,
+            PG_VERSION_12,
             PG_VERSION_17,
         ],
     },

--- a/test/lib/pgBackRestTest/Common/VmTest.pm
+++ b/test/lib/pgBackRestTest/Common/VmTest.pm
@@ -150,11 +150,11 @@ my $oyVm =
 
         &VM_DB =>
         [
-            PG_VERSION_12,
             PG_VERSION_13,
             PG_VERSION_14,
             PG_VERSION_15,
             PG_VERSION_16,
+            PG_VERSION_17,
         ],
 
         &VM_DB_TEST =>
@@ -179,10 +179,11 @@ my $oyVm =
 
         &VM_DB =>
         [
-            PG_VERSION_12,
             PG_VERSION_13,
             PG_VERSION_14,
             PG_VERSION_15,
+            PG_VERSION_16,
+            PG_VERSION_17,
         ],
 
         &VM_DB_TEST =>
@@ -213,6 +214,8 @@ my $oyVm =
             PG_VERSION_13,
             PG_VERSION_14,
             PG_VERSION_15,
+            PG_VERSION_16,
+            PG_VERSION_17,
         ],
 
         &VM_DB_TEST =>


### PR DESCRIPTION
Remove PostgreSQL 12 from F41 and RHEL8 containers

Postgres 12 support in F41 and RHEL8 has been discontinued. The necessary
files have been updated for F41 and RHEL8 containers to work correctly.

1020bc1 - move PG 12 from RHEL8 test container and add PG 16. Also shuffle
PG_VERSION for U20 and U22 test containers.

f76da03 - remove completely PG 12 from RHEL8 and F41. Add support PG 16 and
17 for RHEL8, F41 and U20 containers.

87776bc - change base pg-version for Debian (15->16) and RHEL (12->13). Also
change pg-version-upgrade for Debian (16->17) and RHEL (13->14).

b50ad48 - this commit solves problem with build.

The commit "Update exe.cache..." contains only a subset of changes for the file
"exe.cache" similar to 6c90196.

----------

Commits in the PR shouldn't be squashed to preserve authorship.