### PR TITLE
ADBM-2434: Fix wal filtering when there is no unfinished record at the end of the file

### DIFF
--- a/src/common/walFilter/walFilter.c
+++ b/src/common/walFilter/walFilter.c
@@ -513,8 +513,8 @@ walFilterProcess(THIS_VOID, const Buffer *const input, Buffer *const output)
 
     if (input == NULL)
     {
-        // We have an incomplete record at the end
-        if (this->currentStep != noStep)
+        // We have an incomplete record at the end and we already read something
+        if (this->currentStep != noStep && this->currentStep != stepBeginOfRecord)
         {
             // if xl_info and xl_rmid of the header is in current file then read end of record from next file if it exits
             if (this->gotLen >= this->walInterface.rmidSize)

--- a/src/common/walFilter/walFilter.c
+++ b/src/common/walFilter/walFilter.c
@@ -513,7 +513,7 @@ walFilterProcess(THIS_VOID, const Buffer *const input, Buffer *const output)
 
     if (input == NULL)
     {
-        // We have an incomplete record at the end and we already read something
+        // We have an incomplete record at the end, and we have already read something
         if (this->currentStep != noStep && this->currentStep != stepBeginOfRecord)
         {
             // if xl_info and xl_rmid of the header is in current file then read end of record from next file if it exits


### PR DESCRIPTION
Fix wal filtering when there is no unfinished record at the end of the file

When there is no unfinished record at the end of the WAL segment, the next
record will be read, but when the next page is requested, it will be found that
the segment file has ended. However, since the current step has already been set
to stepBeginOfRecord, it was mistakenly assumed that there is an unfinished
record at the end that needs to be written. And since this is also the beginning
of the page, an attempt will be made to write down its header, which is missing,
which led to a crash.

Fix this by improving the condition for detecting the presence of an unfinished
record at the end of the file. Now it is assumed that the current record is
incomplete only if we have at least started reading the header. A test has also
been added for another edge case if the WAL switch record is located at the very
end of the page.