### PR TITLE
ADBM-2452: Fix the search for near WAL files in other directories during WAL filtering

### DIFF
--- a/src/common/walFilter/walFilter.c
+++ b/src/common/walFilter/walFilter.c
@@ -332,56 +332,43 @@ writeRecord(WalFilterState *const this, Buffer *const output, const unsigned cha
     this->gotLen = 0;
 }
 
+// Based on XLogFilePath from Postgres
+static inline const String *
+xLogFileName (const TimeLineID timeLine, uint64 segno, uint32 segSize)
+{
+    return strNewFmt("%08X%08X%08X", timeLine,
+                     (uint32) ((segno) / XLogSegmentsPerXLogId(segSize)),
+                     (uint32) ((segno) % XLogSegmentsPerXLogId(segSize)));
+}
+
 static const StorageRead *
 getNearWal (WalFilterState *const this, bool isNext)
 {
-    const String *walSegment = NULL;
     const TimeLineID timeLine = this->currentPageHeader->xlp_tli;
     uint64 segno = this->currentPageHeader->xlp_pageaddr / this->segSize;
-    const String *const path = strNewFmt("%08X%08X", timeLine, (uint32) (segno / XLogSegmentsPerXLogId(this->segSize)));
+
+    ASSERT(isNext == true || segno != 0);
+    if (isNext)
+        segno++;
+    else
+        segno--;
+
+    const String *walName = xLogFileName(timeLine, segno, this->segSize);
+
+    String *walDir = strNewFmt("%08X%08X", timeLine, (uint32) (segno / XLogSegmentsPerXLogId(this->segSize)));
 
     const StringList *const segmentList = storageListP(
         storageRepoIdx(this->archiveInfo->repoIdx),
-        strNewFmt(STORAGE_REPO_ARCHIVE "/%s/%s", strZ(this->archiveInfo->archiveId), strZ(path)),
-        .expression = strNewFmt("^[0-f]{24}-[0-f]{40}" COMPRESS_TYPE_REGEXP "{0,1}$"));
+        strNewFmt(STORAGE_REPO_ARCHIVE "/%s/%s", strZ(this->archiveInfo->archiveId), strZ(walDir)),
+        .expression = strNewFmt("^%s-[0-f]{40}" COMPRESS_TYPE_REGEXP "{0,1}$", strZ(walName)));
 
     if (strLstEmpty(segmentList))
     {
-        // an exotic case where we couldn't even find the current file.
-        THROW(FormatError, "no WAL files were found in the repository");
-    }
-
-    uint64 segnoDiff = UINT64_MAX;
-    for (unsigned int i = 0; i < strLstSize(segmentList); i++)
-    {
-        const String *const file = strSubN(strLstGet(segmentList, i), 0, 24);
-        TimeLineID tli;
-        uint64 fileSegNo = 0;
-        XLogFromFileName(strZ(file), &tli, &fileSegNo, this->segSize);
-
-        if (isNext)
-        {
-            if (fileSegNo - segno < segnoDiff && fileSegNo > segno)
-            {
-                segnoDiff = fileSegNo - segno;
-                walSegment = strLstGet(segmentList, i);
-            }
-        }
-        else
-        {
-            if (segno - fileSegNo < segnoDiff && fileSegNo < segno)
-            {
-                segnoDiff = segno - fileSegNo;
-                walSegment = strLstGet(segmentList, i);
-            }
-        }
-    }
-
-    // current file is oldest/newest
-    if (segnoDiff == UINT64_MAX)
-    {
         return NULL;
     }
+
+    ASSERT(strLstSize(segmentList) == 1);
+    const String *walSegment = strLstGet(segmentList, 0);
 
     const bool compressible =
         this->archiveInfo->cipherType == cipherTypeNone && compressTypeFromName(this->archiveInfo->file) == compressTypeNone;

--- a/src/common/walFilter/walFilter.c
+++ b/src/common/walFilter/walFilter.c
@@ -357,10 +357,17 @@ getNearWal (WalFilterState *const this, bool isNext)
 
     String *walDir = strNewFmt("%08X%08X", timeLine, (uint32) (segno / XLogSegmentsPerXLogId(this->segSize)));
 
+    const String *expression;
+    // The next file may be partial if the timeline has been switched.
+    if (isNext)
+        expression = strNewFmt("^%s(\\.partial)?-[0-f]{40}" COMPRESS_TYPE_REGEXP "{0,1}$", strZ(walName));
+    else
+        expression = strNewFmt("^%s-[0-f]{40}" COMPRESS_TYPE_REGEXP "{0,1}$", strZ(walName));
+
     const StringList *const segmentList = storageListP(
         storageRepoIdx(this->archiveInfo->repoIdx),
         strNewFmt(STORAGE_REPO_ARCHIVE "/%s/%s", strZ(this->archiveInfo->archiveId), strZ(walDir)),
-        .expression = strNewFmt("^%s-[0-f]{40}" COMPRESS_TYPE_REGEXP "{0,1}$", strZ(walName)));
+        .expression = expression);
 
     if (strLstEmpty(segmentList))
     {

--- a/test/src/module/common/walFilterGPDB6Test.c
+++ b/test/src/module/common/walFilterGPDB6Test.c
@@ -223,6 +223,59 @@ testRun(void)
             STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000002-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd");
         MEM_CONTEXT_TEMP_END();
 
+        TEST_TITLE("prev file is in the another directory");
+        MEM_CONTEXT_TEMP_BEGIN();
+        archiveInfo.file = STRDEF(
+            STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000001/000000010000000100000000-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd");
+        filter = walFilterNew(pgControl, &archiveInfo);
+        {
+            Buffer *wal1 = bufNew(DEFAULT_GDPB_XLOG_PAGE_SIZE);
+            // LPH - long page header (40 bytes)
+            // SPH - short page header (24 bytes)
+            // RH  - record header (32 bytes)
+            // RM  - remaining data from prev page (var len)
+            // B   - record body (var len)
+            // layout of the first file:
+            // 40  24 32688 8  |
+            // LPH 32   B   RH |
+            record = createXRecord(
+                RM_XLOG_ID, XLOG_NOOP, .body_size = DEFAULT_GDPB_XLOG_PAGE_SIZE - SizeOfXLogLongPHD - SizeOfXLogRecordGPDB6 - 8);
+            insertXRecord(wal1, record, NO_FLAGS, .segno = 63);
+
+            record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = 100);
+            insertXRecord(wal1, record, INCOMPLETE_RECORD, .segno = 63);
+            fillLastPage(wal1, DEFAULT_GDPB_XLOG_PAGE_SIZE);
+
+            HRN_STORAGE_PUT(
+                storageRepoWrite(),
+                STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/00000001000000000000003F-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
+                wal1);
+        }
+
+        wal2 = bufNew(DEFAULT_GDPB_XLOG_PAGE_SIZE);
+        // LPH - long page header (40 bytes)
+        // SPH - short page header (24 bytes)
+        // RH  - record header (32 bytes)
+        // RM  - remaining data from prev page (var len)
+        // B   - record body (var len)
+        // layout of the first file:
+        // 40  124 32
+        // LPH RM  RH
+        record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = 100);
+        hrnGpdbWalInsertXRecordP(wal2, record, NO_FLAGS, .segno = 64, .beginOffset = 132 - 8);
+        insertWalSwitchXRecord(wal2);
+
+        fillLastPage(wal2, DEFAULT_GDPB_XLOG_PAGE_SIZE);
+        result = testFilter(filter, wal2, bufSize(wal2), bufSize(wal2));
+        TEST_RESULT_BOOL(bufEq(wal2, result), true, "WAL not the same");
+
+        HRN_STORAGE_REMOVE(
+            storageRepoWrite(),
+            STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/00000001000000000000003F-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd");
+        archiveInfo.file = STRDEF(
+            STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000002-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd");
+        MEM_CONTEXT_TEMP_END();
+
         TEST_TITLE("incomplete record in the beginning of prev file");
         MEM_CONTEXT_TEMP_BEGIN();
         filter = walFilterNew(pgControl, &archiveInfo);
@@ -420,6 +473,39 @@ testRun(void)
             STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000033-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd");
         MEM_CONTEXT_TEMP_END();
 
+        TEST_TITLE("no prev file for this backup");
+        MEM_CONTEXT_TEMP_BEGIN();
+        filter = walFilterNew(pgControl, &archiveInfo);
+        {
+            Buffer *zeros = bufNew(DEFAULT_GDPB_XLOG_PAGE_SIZE);
+            memset(bufPtr(zeros), 0, bufUsed(zeros));
+
+            HRN_STORAGE_PUT(
+                storageRepoWrite(),
+                STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000001-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
+                zeros);
+            HRN_STORAGE_PUT(
+                storageRepoWrite(),
+                STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000002-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
+                zeros);
+        }
+
+        wal2 = bufNew(1024 * 1024);
+        record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = 100);
+        hrnGpdbWalInsertXRecordP(wal2, record, NO_FLAGS, .segno = 10, .beginOffset = 132 - 8);
+        insertWalSwitchXRecord(wal2);
+        fillLastPage(wal2, DEFAULT_GDPB_XLOG_PAGE_SIZE);
+        result = testFilter(filter, wal2, bufSize(wal2), bufSize(wal2));
+        TEST_RESULT_BOOL(bufEq(wal2, result), true, "WAL not the same");
+
+        HRN_STORAGE_REMOVE(
+            storageRepoWrite(),
+            STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000001-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd");
+        HRN_STORAGE_REMOVE(
+            storageRepoWrite(),
+            STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000002-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd");
+        MEM_CONTEXT_TEMP_END();
+
         TEST_TITLE("no WAL files in repository");
         MEM_CONTEXT_TEMP_BEGIN();
         filter = walFilterNew(pgControl, &archiveInfo);
@@ -430,10 +516,8 @@ testRun(void)
         insertWalSwitchXRecord(wal2);
 
         fillLastPage(wal2, DEFAULT_GDPB_XLOG_PAGE_SIZE);
-        TEST_ERROR(
-            testFilter(filter, wal2, bufSize(wal2), bufSize(wal2)),
-            FormatError,
-            "no WAL files were found in the repository");
+        result = testFilter(filter, wal2, bufSize(wal2), bufSize(wal2));
+        TEST_RESULT_BOOL(bufEq(wal2, result), true, "WAL not the same");
 
         MEM_CONTEXT_TEMP_END();
 
@@ -842,7 +926,7 @@ testRun(void)
 
             HRN_STORAGE_PUT(
                 storageRepoWrite(),
-                STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000002-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
+                STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000001-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
                 wal1);
         }
 
@@ -862,7 +946,47 @@ testRun(void)
 
         HRN_STORAGE_REMOVE(
             storageRepoWrite(),
-            STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000002-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd");
+            STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000001-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd");
+        MEM_CONTEXT_TEMP_END();
+
+        TEST_TITLE("next file in the auther directory");
+        archiveInfo.file = STRDEF("/9.4-1/0000000100000000/00000001000000000000003F-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd");
+        MEM_CONTEXT_TEMP_BEGIN();
+        filter = walFilterNew(pgControl, &archiveInfo);
+        {
+            Buffer *wal1 = bufNew(DEFAULT_GDPB_XLOG_PAGE_SIZE);
+
+            record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = 100);
+            insertXRecord(wal1, record, 0, .beginOffset = 100, .segno = 63);
+            fillLastPage(wal1, DEFAULT_GDPB_XLOG_PAGE_SIZE);
+
+            HRN_STORAGE_PUT(
+                storageRepoWrite(),
+                STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000001/000000010000000100000000-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
+                wal1);
+        }
+
+        wal2 = bufNew(GPDB_XLOG_SEG_SIZE);
+
+        // GPDB_XLOG_SEG_SIZE = 64*1024*1024 = 67108864
+        // GPDB_XLOG_SEG_SIZE / DEFAULT_GDPB_XLOG_PAGE_SIZE = 2048
+        // 2047 * SizeOfXLogShortPHD = 49128
+        // 49128 + SizeOfXLogLongPHD + SizeOfXLogRecordGPDB6 = 49200
+        // 67108864 - 49200 = 67059664
+        // 67059664 - SizeOfXLogRecordGPDB6 = 67059632
+        record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = 67059632);
+
+        insertXRecord(wal2, record, NO_FLAGS, .segno = 63);
+        record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = 100);
+        insertXRecord(wal2, record, INCOMPLETE_RECORD, .segno = 63);
+
+        fillLastPage(wal2, DEFAULT_GDPB_XLOG_PAGE_SIZE);
+        result = testFilter(filter, wal2, bufSize(wal2), bufSize(wal2));
+        TEST_RESULT_BOOL(bufEq(wal2, result), true, "WAL not the same");
+
+        HRN_STORAGE_REMOVE(
+            storageRepoWrite(),
+            STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000001/000000010000000100000000-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd");
         MEM_CONTEXT_TEMP_END();
 
         TEST_TITLE("no files in repository");
@@ -878,7 +1002,7 @@ testRun(void)
 
         fillLastPage(wal2, DEFAULT_GDPB_XLOG_PAGE_SIZE);
         TEST_ERROR(
-            testFilter(filter, wal2, bufSize(wal2), bufSize(wal2)), FormatError, "no WAL files were found in the repository");
+            testFilter(filter, wal2, bufSize(wal2), bufSize(wal2)), FormatError, "The file with the end of the 0/7ff0 record is missing");
 
         MEM_CONTEXT_TEMP_END();
 
@@ -1061,7 +1185,7 @@ testRun(void)
             bufResize(wal1, DEFAULT_GDPB_XLOG_PAGE_SIZE * 2);
             HRN_STORAGE_PUT(
                 storageRepoWrite(),
-                STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000002-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
+                STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000001-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
                 wal1);
         }
 
@@ -1080,7 +1204,7 @@ testRun(void)
 
         HRN_STORAGE_REMOVE(
             storageRepoWrite(),
-            STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000002-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd");
+            STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000001-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd");
         MEM_CONTEXT_TEMP_END();
 
         TEST_TITLE("usefully part of header in the next file");
@@ -1105,7 +1229,7 @@ testRun(void)
 
             HRN_STORAGE_PUT(
                 storageRepoWrite(),
-                STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000002-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
+                STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000001-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
                 wal1);
         }
 
@@ -1130,7 +1254,7 @@ testRun(void)
 
         HRN_STORAGE_REMOVE(
             storageRepoWrite(),
-            STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000002-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd");
+            STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000001-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd");
         MEM_CONTEXT_TEMP_END();
 
         TEST_TITLE("compressed and encrypted WAL file");

--- a/test/src/module/common/walFilterGPDB6Test.c
+++ b/test/src/module/common/walFilterGPDB6Test.c
@@ -223,6 +223,35 @@ testRun(void)
             STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000002-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd");
         MEM_CONTEXT_TEMP_END();
 
+        TEST_TITLE("prev file is partial");
+        MEM_CONTEXT_TEMP_BEGIN();
+        filter = walFilterNew(pgControl, &archiveInfo);
+        {
+            Buffer *zeros = bufNew(DEFAULT_GDPB_XLOG_PAGE_SIZE);
+            memset(bufPtr(zeros), 0, bufUsed(zeros));
+
+            HRN_STORAGE_PUT(
+                storageRepoWrite(),
+                STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000001.partial-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
+                zeros);
+        }
+
+        wal2 = bufNew(1024 * 1024);
+        record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = 100);
+        hrnGpdbWalInsertXRecordP(wal2, record, NO_FLAGS, .segno = 2, .beginOffset = 132 - 8);
+        insertWalSwitchXRecord(wal2);
+
+        fillLastPage(wal2, DEFAULT_GDPB_XLOG_PAGE_SIZE);
+        result = testFilter(filter, wal2, bufSize(wal2), bufSize(wal2));
+        TEST_RESULT_BOOL(bufEq(wal2, result), true, "WAL not the same");
+
+        HRN_STORAGE_REMOVE(
+            storageRepoWrite(),
+            STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000001.partial-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd");
+        archiveInfo.file = STRDEF(
+            STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000002-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd");
+        MEM_CONTEXT_TEMP_END();
+
         TEST_TITLE("prev file is in the another directory");
         MEM_CONTEXT_TEMP_BEGIN();
         archiveInfo.file = STRDEF(
@@ -949,7 +978,44 @@ testRun(void)
             STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000001-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd");
         MEM_CONTEXT_TEMP_END();
 
-        TEST_TITLE("next file in the auther directory");
+        TEST_TITLE("the next file is partial");
+        MEM_CONTEXT_TEMP_BEGIN();
+        PgControl testPgControl = pgControl;
+        testPgControl.walSegmentSize = DEFAULT_GDPB_XLOG_PAGE_SIZE;
+        filter = walFilterNew(testPgControl, &archiveInfo);
+        {
+            Buffer *wal1 = bufNew(DEFAULT_GDPB_XLOG_PAGE_SIZE);
+
+            record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = 100);
+            insertXRecord(wal1, record, 0, .beginOffset = 100);
+            fillLastPage(wal1, DEFAULT_GDPB_XLOG_PAGE_SIZE);
+
+            HRN_STORAGE_PUT(
+                storageRepoWrite(),
+                STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000001.partial-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
+                wal1);
+        }
+
+        wal2 = bufNew(1024 * 1024);
+        // Subtract SizeOfXLogRecord twice to leave exactly space at the end of the page for the header of the next record.
+        record = createXRecord(
+            RM_XLOG_ID,
+            XLOG_NOOP,
+            .body_size = DEFAULT_GDPB_XLOG_PAGE_SIZE - SizeOfXLogLongPHD - SizeOfXLogRecordGPDB6 - SizeOfXLogRecordGPDB6);
+        insertXRecord(wal2, record, NO_FLAGS);
+        record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = 100);
+        insertXRecord(wal2, record, INCOMPLETE_RECORD, .segno = 1);
+
+        fillLastPage(wal2, DEFAULT_GDPB_XLOG_PAGE_SIZE);
+        result = testFilter(filter, wal2, bufSize(wal2), bufSize(wal2));
+        TEST_RESULT_BOOL(bufEq(wal2, result), true, "WAL not the same");
+
+        HRN_STORAGE_REMOVE(
+            storageRepoWrite(),
+            STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000001.partial-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd");
+        MEM_CONTEXT_TEMP_END();
+
+        TEST_TITLE("next file in the another directory");
         archiveInfo.file = STRDEF("/9.4-1/0000000100000000/00000001000000000000003F-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd");
         MEM_CONTEXT_TEMP_BEGIN();
         filter = walFilterNew(pgControl, &archiveInfo);

--- a/test/src/module/common/walFilterGPDB6Test.c
+++ b/test/src/module/common/walFilterGPDB6Test.c
@@ -955,7 +955,7 @@ testRun(void)
 
             HRN_STORAGE_PUT(
                 storageRepoWrite(),
-                STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000001-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
+                STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000002-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
                 wal1);
         }
 
@@ -965,9 +965,9 @@ testRun(void)
             RM_XLOG_ID,
             XLOG_NOOP,
             .body_size = DEFAULT_GDPB_XLOG_PAGE_SIZE - SizeOfXLogLongPHD - SizeOfXLogRecordGPDB6 - SizeOfXLogRecordGPDB6);
-        insertXRecord(wal2, record, NO_FLAGS);
+        insertXRecord(wal2, record, NO_FLAGS, .segno = 1, .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE);
         record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = 100);
-        insertXRecord(wal2, record, INCOMPLETE_RECORD, .segno = 1);
+        insertXRecord(wal2, record, INCOMPLETE_RECORD, .segno = 1, .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE);
 
         fillLastPage(wal2, DEFAULT_GDPB_XLOG_PAGE_SIZE);
         result = testFilter(filter, wal2, bufSize(wal2), bufSize(wal2));
@@ -975,7 +975,7 @@ testRun(void)
 
         HRN_STORAGE_REMOVE(
             storageRepoWrite(),
-            STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000001-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd");
+            STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000002-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd");
         MEM_CONTEXT_TEMP_END();
 
         TEST_TITLE("the next file is partial");
@@ -1251,7 +1251,7 @@ testRun(void)
             bufResize(wal1, DEFAULT_GDPB_XLOG_PAGE_SIZE * 2);
             HRN_STORAGE_PUT(
                 storageRepoWrite(),
-                STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000001-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
+                STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000002-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
                 wal1);
         }
 
@@ -1261,16 +1261,16 @@ testRun(void)
             RM_XLOG_ID,
             XLOG_NOOP,
             .body_size = DEFAULT_GDPB_XLOG_PAGE_SIZE - SizeOfXLogLongPHD - SizeOfXLogRecordGPDB6 - SizeOfXLogRecordGPDB6);
-        insertXRecord(wal2, record, NO_FLAGS);
+        insertXRecord(wal2, record, NO_FLAGS, .segno = 1);
         record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = (DEFAULT_GDPB_XLOG_PAGE_SIZE * 2) - SizeOfXLogRecordGPDB6);
         insertXRecord(wal2, record, INCOMPLETE_RECORD, .segno = 1);
 
         fillLastPage(wal2, DEFAULT_GDPB_XLOG_PAGE_SIZE);
-        TEST_ERROR(testFilter(filter, wal2, bufSize(wal2), bufSize(wal2)), FormatError, "0/7fe0 - Unexpected WAL end");
+        TEST_ERROR(testFilter(filter, wal2, bufSize(wal2), bufSize(wal2)), FormatError, "0/4007fe0 - Unexpected WAL end");
 
         HRN_STORAGE_REMOVE(
             storageRepoWrite(),
-            STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000001-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd");
+            STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000002-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd");
         MEM_CONTEXT_TEMP_END();
 
         TEST_TITLE("usefully part of header in the next file");
@@ -1295,7 +1295,7 @@ testRun(void)
 
             HRN_STORAGE_PUT(
                 storageRepoWrite(),
-                STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000001-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
+                STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000002-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
                 wal1);
         }
 
@@ -1310,7 +1310,7 @@ testRun(void)
         // LPH RH   B   RH |
         record = createXRecord(
             RM_XLOG_ID, XLOG_NOOP, .body_size = DEFAULT_GDPB_XLOG_PAGE_SIZE - SizeOfXLogLongPHD - SizeOfXLogRecordGPDB6 - 8);
-        insertXRecord(wal2, record, NO_FLAGS, .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE);
+        insertXRecord(wal2, record, NO_FLAGS, .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE, .segno = 1);
         record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = 100);
         insertXRecord(wal2, record, INCOMPLETE_RECORD, .segno = 1, .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE);
 
@@ -1320,7 +1320,7 @@ testRun(void)
 
         HRN_STORAGE_REMOVE(
             storageRepoWrite(),
-            STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000001-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd");
+            STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000002-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd");
         MEM_CONTEXT_TEMP_END();
 
         TEST_TITLE("compressed and encrypted WAL file");

--- a/test/src/module/common/walFilterGPDB7Test.c
+++ b/test/src/module/common/walFilterGPDB7Test.c
@@ -294,7 +294,7 @@ testRun(void)
 
             HRN_STORAGE_PUT(
                 storageRepoWrite(),
-                STORAGE_REPO_ARCHIVE "/12-1/0000000100000000/000000010000000000000001-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
+                STORAGE_REPO_ARCHIVE "/12-1/0000000100000000/000000010000000000000002-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
                 wal1);
         }
 
@@ -304,9 +304,9 @@ testRun(void)
             RM_XLOG_ID,
             XLOG_NOOP,
             .main_data_size = DEFAULT_GDPB_XLOG_PAGE_SIZE - SizeOfXLogLongPHD - sizeof(XLogRecordGPDB7) - 1 - 4 - 16);
-        insertXRecord(wal2, record, NO_FLAGS);
+        insertXRecord(wal2, record, NO_FLAGS, .segno = 1, .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE);
         record = createXRecord(RM7_XACT_ID, XLOG_XACT_COMMIT, .main_data_size = 100);
-        insertXRecord(wal2, record, INCOMPLETE_RECORD, .segno = 1);
+        insertXRecord(wal2, record, INCOMPLETE_RECORD, .segno = 1, .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE);
 
         fillLastPage(wal2, DEFAULT_GDPB_XLOG_PAGE_SIZE);
         result = testFilter(filter, wal2, bufSize(wal2), bufSize(wal2));
@@ -314,7 +314,7 @@ testRun(void)
 
         HRN_STORAGE_REMOVE(
             storageRepoWrite(),
-            STORAGE_REPO_ARCHIVE "/12-1/0000000100000000/000000010000000000000001-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd");
+            STORAGE_REPO_ARCHIVE "/12-1/0000000100000000/000000010000000000000002-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd");
         MEM_CONTEXT_TEMP_END();
     }
 

--- a/test/src/module/common/walFilterGPDB7Test.c
+++ b/test/src/module/common/walFilterGPDB7Test.c
@@ -294,7 +294,7 @@ testRun(void)
 
             HRN_STORAGE_PUT(
                 storageRepoWrite(),
-                STORAGE_REPO_ARCHIVE "/12-1/0000000100000000/000000010000000000000002-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
+                STORAGE_REPO_ARCHIVE "/12-1/0000000100000000/000000010000000000000001-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
                 wal1);
         }
 
@@ -314,7 +314,7 @@ testRun(void)
 
         HRN_STORAGE_REMOVE(
             storageRepoWrite(),
-            STORAGE_REPO_ARCHIVE "/12-1/0000000100000000/000000010000000000000002-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd");
+            STORAGE_REPO_ARCHIVE "/12-1/0000000100000000/000000010000000000000001-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd");
         MEM_CONTEXT_TEMP_END();
     }
 
@@ -1170,7 +1170,7 @@ testRun(void)
             Buffer *wal1 = bufNew(DEFAULT_GDPB_XLOG_PAGE_SIZE);
 
             record = createXRecord(RM7_XACT_ID, XLOG_XACT_COMMIT, .backupBlocks = backupBlocks);
-            insertXRecord(wal1, record, NO_FLAGS, .beginOffset = record->xl_tot_len - 24);
+            insertXRecord(wal1, record, NO_FLAGS, .beginOffset = record->xl_tot_len - 24, .segno = 2, .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE);
             fillLastPage(wal1, DEFAULT_GDPB_XLOG_PAGE_SIZE);
 
             HRN_STORAGE_PUT(
@@ -1185,9 +1185,9 @@ testRun(void)
             RM_XLOG_ID,
             XLOG_NOOP,
             .main_data_size = DEFAULT_GDPB_XLOG_PAGE_SIZE - SizeOfXLogLongPHD - sizeof(XLogRecordGPDB7) - 1 - 4 - 24);
-        insertXRecord(wal2, record, NO_FLAGS);
+        insertXRecord(wal2, record, NO_FLAGS, .segno = 1, .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE);
         record = createXRecord(RM7_XACT_ID, XLOG_XACT_COMMIT, .backupBlocks = backupBlocks);
-        insertXRecord(wal2, record, INCOMPLETE_RECORD, .segno = 1);
+        insertXRecord(wal2, record, INCOMPLETE_RECORD, .segno = 1, .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE);
         fillLastPage(wal2, DEFAULT_GDPB_XLOG_PAGE_SIZE);
 
         Buffer *wal2_expected = bufNew(DEFAULT_GDPB_XLOG_PAGE_SIZE);
@@ -1195,11 +1195,11 @@ testRun(void)
             RM_XLOG_ID,
             XLOG_NOOP,
             .main_data_size = DEFAULT_GDPB_XLOG_PAGE_SIZE - SizeOfXLogLongPHD - sizeof(XLogRecordGPDB7) - 1 - 4 - 24);
-        insertXRecord(wal2_expected, record, NO_FLAGS);
+        insertXRecord(wal2_expected, record, NO_FLAGS, .segno = 1, .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE);
         record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .backupBlocks = backupBlocks);
         overrideXLogRecordBody((XLogRecordGPDB7 *) record);
         ((XLogRecordGPDB7 *) record)->xl_crc = xLogRecordChecksumGPDB7((XLogRecordGPDB7 *) record);
-        insertXRecord(wal2_expected, record, INCOMPLETE_RECORD, .segno = 1);
+        insertXRecord(wal2_expected, record, INCOMPLETE_RECORD, .segno = 1, .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE);
         fillLastPage(wal2_expected, DEFAULT_GDPB_XLOG_PAGE_SIZE);
 
         result = testFilter(filter, wal2, bufSize(wal2), bufSize(wal2));


### PR DESCRIPTION
While filtering WAL files, near files may be requested. The WAL archive stores
by 64 files per directory based on LSN. Therefore, the nearest files may be
located in a different directory. This could lead to error when requesting the
nearest files, since the search took place only in the same directory as the
current WAL file.
Also, this logic could lead to the fact that we could take a file from another
backup as a previous file if one of the previous backups was deleted. Which
also led to an error.

Fix this by changing the logic of searching for the nearest WAL files. Now,
instead of getting all the files in the directory and searching for the nearest
one from the right side, only the strictly next or previous file is searched. It
is also taken into account that the file may be located in another directory.
In addition, the problem with the case when the next file is on a different
timeline has been fixed. To do this, we are also looking for files with the
'partial' suffix for the next files.