### PR TITLE
ADBM-2453: Remove record is too big error

### DIFF
--- a/src/common/walFilter/walFilter.c
+++ b/src/common/walFilter/walFilter.c
@@ -40,7 +40,9 @@ typedef struct WalFilter
     uint32 segSize;
 
     bool isBegin;
+    bool isReadOrphanedData;
 
+    size_t beginOffset;
     size_t pageOffset;
     size_t inputOffset;
     XLogRecPtr recPtr;
@@ -284,6 +286,14 @@ stepReadBody:
 static void
 writeRecord(WalFilterState *const this, Buffer *const output, const unsigned char *recordData)
 {
+    // We are in the beginning of the segment file, and we have an incomplete record from the previous segment.
+    if (this->beginOffset != 0)
+    {
+        this->gotLen -= this->beginOffset;
+        recordData += this->beginOffset;
+        this->beginOffset = 0;
+    }
+
     uint32 header_i = 0;
     if (this->recPtr % this->walPageSize == 0)
     {
@@ -511,6 +521,9 @@ walFilterProcess(THIS_VOID, const Buffer *const input, Buffer *const output)
     // Avoid creating local variables before the record is fully read,
     // since if the input buffer is exhausted, we can exit the function.
 
+    if (this->isReadOrphanedData)
+        goto readOrphanedData;
+
     if (input == NULL)
     {
         // We have an incomplete record at the end, and we have already read something
@@ -540,45 +553,39 @@ walFilterProcess(THIS_VOID, const Buffer *const input, Buffer *const output)
             if (readBeginOfRecord(this))
             {
                 // Remember how much we read from the prev file in order to skip this size when writing.
-                const size_t offset = this->gotLen;
+                this->beginOffset = this->gotLen;
                 this->inputOffset = 0;
                 lstClearFast(this->pageHeaders);
-                if (readRecord(this, input) == ReadRecordNeedBuffer)
+            }
+            else
+            {
+                this->inputOffset = 0;
+                this->isReadOrphanedData = true;
+                do
                 {
-                    // Since we are at the very beginning of the file, let's assume that the current input buffer is enough to fully
-                    // read this record.
-                    THROW_FMT(FormatError, "%s - record is too big", strZ(pgLsnToStr(this->recPtr)));
+readOrphanedData:
+                    if (!getNextPage(this, input))
+                    {
+                        this->inputSame = false;
+                        this->inputOffset = 0;
+                        goto end;
+                    }
+                    bufCatC(
+                        output, (const unsigned char *) this->currentPageHeader, 0, XLogPageHeaderSize(this->currentPageHeader));
+                    ASSERT(this->recPtr == this->currentPageHeader->xlp_pageaddr);
+                    this->recPtr += XLogPageHeaderSize(this->currentPageHeader);
+
+                    size_t toCopy = Min(MAXALIGN(this->currentPageHeader->xlp_rem_len), this->walPageSize - this->pageOffset);
+                    ASSERT(!(this->currentPageHeader->xlp_info & XLP_FIRST_IS_OVERWRITE_CONTRECORD) || toCopy == 0);
+                    bufCatC(output, (const unsigned char *) this->currentPageHeader, this->pageOffset, toCopy);
+                    this->recPtr += toCopy;
                 }
-                this->walInterface.xLogRecordFilter(this->record);
-
-                ASSERT(offset < this->gotLen);
-                this->gotLen -= offset;
-
-                writeRecord(this, output, ((const unsigned char *) this->record) + offset);
+                while (this->currentPageHeader->xlp_rem_len > this->walPageSize - this->pageOffset);
+                this->isReadOrphanedData = false;
+                this->pageOffset += MAXALIGN(this->currentPageHeader->xlp_rem_len);
                 this->inputSame = true;
                 lstClearFast(this->pageHeaders);
-                goto end;
             }
-
-            this->inputOffset = 0;
-            do
-            {
-                if (!getNextPage(this, input))
-                {
-                    THROW_FMT(FormatError, "%s - record is too big", strZ(pgLsnToStr(this->recPtr)));
-                }
-                bufCatC(output, (const unsigned char *) this->currentPageHeader, 0, XLogPageHeaderSize(this->currentPageHeader));
-                ASSERT(this->recPtr == this->currentPageHeader->xlp_pageaddr);
-                this->recPtr += XLogPageHeaderSize(this->currentPageHeader);
-
-                size_t toCopy = Min(MAXALIGN(this->currentPageHeader->xlp_rem_len), this->walPageSize - this->pageOffset);
-                ASSERT(!(this->currentPageHeader->xlp_info & XLP_FIRST_IS_OVERWRITE_CONTRECORD) || toCopy == 0);
-                bufCatC(output, (const unsigned char *) this->currentPageHeader, this->pageOffset, toCopy);
-                this->recPtr += toCopy;
-            }
-            while (this->currentPageHeader->xlp_rem_len > this->walPageSize - this->pageOffset);
-            this->pageOffset += MAXALIGN(this->currentPageHeader->xlp_rem_len);
-            lstClearFast(this->pageHeaders);
         }
     }
 

--- a/src/common/walFilter/walFilter.c
+++ b/src/common/walFilter/walFilter.c
@@ -40,8 +40,10 @@ typedef struct WalFilter
     uint32 segSize;
 
     bool isBegin;
+    // Are we reading remaining data of incomplete record?
     bool isReadOrphanedData;
 
+    // How many bytes of the record are in the previous file
     size_t beginOffset;
     size_t pageOffset;
     size_t inputOffset;
@@ -583,7 +585,6 @@ readOrphanedData:
                 while (this->currentPageHeader->xlp_rem_len > this->walPageSize - this->pageOffset);
                 this->isReadOrphanedData = false;
                 this->pageOffset += MAXALIGN(this->currentPageHeader->xlp_rem_len);
-                this->inputSame = true;
                 lstClearFast(this->pageHeaders);
             }
         }

--- a/test/src/module/common/walFilterGPDB6Test.c
+++ b/test/src/module/common/walFilterGPDB6Test.c
@@ -471,7 +471,7 @@ testRun(void)
             STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000001-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd");
         MEM_CONTEXT_TEMP_END();
 
-        TEST_TITLE("record is too big");
+        TEST_TITLE("record is larger than bufer with prev file");
         MEM_CONTEXT_TEMP_BEGIN();
         filter = walFilterNew(pgControl, &archiveInfo);
         {
@@ -497,10 +497,8 @@ testRun(void)
         insertWalSwitchXRecord(wal2);
 
         fillLastPage(wal2, DEFAULT_GDPB_XLOG_PAGE_SIZE);
-        TEST_ERROR(
-            testFilter(filter, wal2, DEFAULT_GDPB_XLOG_PAGE_SIZE, DEFAULT_GDPB_XLOG_PAGE_SIZE),
-            FormatError,
-            "0/8000000 - record is too big");
+        result = testFilter(filter, wal2, bufSize(wal2), bufSize(wal2));
+        TEST_RESULT_BOOL(bufEq(wal2, result), true, "WAL not the same");
 
         HRN_STORAGE_REMOVE(
             storageRepoWrite(),
@@ -683,7 +681,7 @@ testRun(void)
             STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000001-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd");
         MEM_CONTEXT_TEMP_END();
 
-        TEST_TITLE("long record at the end of the previous file - record is too big");
+        TEST_TITLE("long record at the end of the previous file with small buffer");
         MEM_CONTEXT_TEMP_BEGIN();
         filter = walFilterNew(pgControl, &archiveInfo);
         {
@@ -716,7 +714,8 @@ testRun(void)
         insertWalSwitchXRecord(wal2);
 
         fillLastPage(wal2, DEFAULT_GDPB_XLOG_PAGE_SIZE);
-        TEST_ERROR(testFilter(filter, wal2, DEFAULT_GDPB_XLOG_PAGE_SIZE, 1024 * 1024), FormatError, "0/8008000 - record is too big");
+        result = testFilter(filter, wal2, DEFAULT_GDPB_XLOG_PAGE_SIZE, 1024 * 1024);
+        TEST_RESULT_BOOL(bufEq(wal2, result), true, "WAL not the same");
 
         HRN_STORAGE_REMOVE(
             storageRepoWrite(),

--- a/test/src/module/common/walFilterGPDB6Test.c
+++ b/test/src/module/common/walFilterGPDB6Test.c
@@ -497,7 +497,7 @@ testRun(void)
         insertWalSwitchXRecord(wal2);
 
         fillLastPage(wal2, DEFAULT_GDPB_XLOG_PAGE_SIZE);
-        result = testFilter(filter, wal2, bufSize(wal2), bufSize(wal2));
+        result = testFilter(filter, wal2, DEFAULT_GDPB_XLOG_PAGE_SIZE, DEFAULT_GDPB_XLOG_PAGE_SIZE);
         TEST_RESULT_BOOL(bufEq(wal2, result), true, "WAL not the same");
 
         HRN_STORAGE_REMOVE(

--- a/test/src/module/common/walFilterGPDB6Test.c
+++ b/test/src/module/common/walFilterGPDB6Test.c
@@ -471,7 +471,7 @@ testRun(void)
             STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000001-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd");
         MEM_CONTEXT_TEMP_END();
 
-        TEST_TITLE("record is larger than bufer with prev file");
+        TEST_TITLE("record is larger than buffer with prev file");
         MEM_CONTEXT_TEMP_BEGIN();
         filter = walFilterNew(pgControl, &archiveInfo);
         {


### PR DESCRIPTION
This error meant that the input buffer was not enough to read the unfinished
record at the beginning of the file. It was considered an unlikely situation.
But practice has shown that this situation is possible.

Fix it by getting rid of this error. Now, if there is not enough input buffer,
we can request the next buffer. Also, the logic of reading an unfinished record
at the beginning of a file, if there is a previous file, is unified with the
general logic of reading records.