### PR TITLE
Issue a warning when missing WAL file

### DIFF
--- a/src/common/walFilter/walFilter.c
+++ b/src/common/walFilter/walFilter.c
@@ -411,6 +411,7 @@ readBeginOfRecord(WalFilterState *const this)
 
     if (storageRead == NULL)
     {
+        LOG_WARN_FMT("%s - Missing previous WAL file. Is current file is first in the chain?", strZ(pgLsnToStr(this->recPtr)));
         goto end;
     }
 
@@ -476,7 +477,9 @@ getEndOfRecord(WalFilterState *const this)
 
     if (storageRead == NULL)
     {
-        THROW_FMT(FormatError, "The file with the end of the %s record is missing", strZ(pgLsnToStr(this->recPtr)));
+        LOG_WARN_FMT(
+            "The file with the end of the %s record is missing. Has the timeline switch happened?", strZ(pgLsnToStr(this->recPtr)));
+        goto end;
     }
 
     ioReadOpen(storageReadIo(storageRead));
@@ -496,6 +499,7 @@ getEndOfRecord(WalFilterState *const this)
         bufUsedSet(buffer, size);
     }
     ioReadClose(storageReadIo(storageRead));
+end:
     MEM_CONTEXT_TEMP_END();
 }
 

--- a/test/src/module/common/walFilterGPDB6Test.c
+++ b/test/src/module/common/walFilterGPDB6Test.c
@@ -244,6 +244,7 @@ testRun(void)
         fillLastPage(wal2, DEFAULT_GDPB_XLOG_PAGE_SIZE);
         result = testFilter(filter, wal2, bufSize(wal2), bufSize(wal2));
         TEST_RESULT_BOOL(bufEq(wal2, result), true, "WAL not the same");
+        TEST_RESULT_LOG("P00   WARN: 0/8000000 - Missing previous WAL file. Is current file is first in the chain?");
 
         HRN_STORAGE_REMOVE(
             storageRepoWrite(),
@@ -496,6 +497,7 @@ testRun(void)
         fillLastPage(wal2, DEFAULT_GDPB_XLOG_PAGE_SIZE);
         result = testFilter(filter, wal2, bufSize(wal2), bufSize(wal2));
         TEST_RESULT_BOOL(bufEq(wal2, result), true, "WAL not the same");
+        TEST_RESULT_LOG("P00   WARN: 0/8000000 - Missing previous WAL file. Is current file is first in the chain?");
 
         HRN_STORAGE_REMOVE(
             storageRepoWrite(),
@@ -526,6 +528,7 @@ testRun(void)
         fillLastPage(wal2, DEFAULT_GDPB_XLOG_PAGE_SIZE);
         result = testFilter(filter, wal2, bufSize(wal2), bufSize(wal2));
         TEST_RESULT_BOOL(bufEq(wal2, result), true, "WAL not the same");
+        TEST_RESULT_LOG("P00   WARN: 0/28000000 - Missing previous WAL file. Is current file is first in the chain?");
 
         HRN_STORAGE_REMOVE(
             storageRepoWrite(),
@@ -547,6 +550,7 @@ testRun(void)
         fillLastPage(wal2, DEFAULT_GDPB_XLOG_PAGE_SIZE);
         result = testFilter(filter, wal2, bufSize(wal2), bufSize(wal2));
         TEST_RESULT_BOOL(bufEq(wal2, result), true, "WAL not the same");
+        TEST_RESULT_LOG("P00   WARN: 0/8000000 - Missing previous WAL file. Is current file is first in the chain?");
 
         MEM_CONTEXT_TEMP_END();
 
@@ -736,6 +740,7 @@ testRun(void)
         fillLastPage(wal2, DEFAULT_GDPB_XLOG_PAGE_SIZE);
         result = testFilter(filter, wal2, 1024 * 1024, 1024 * 1024);
         TEST_RESULT_BOOL(bufEq(wal2, result), true, "WAL not the same");
+        TEST_RESULT_LOG("P00   WARN: 0/8000000 - Missing previous WAL file. Is current file is first in the chain?");
 
         HRN_STORAGE_REMOVE(
             storageRepoWrite(),
@@ -829,6 +834,7 @@ testRun(void)
         fillLastPage(wal2, DEFAULT_GDPB_XLOG_PAGE_SIZE);
         result = testFilter(filter, wal2, DEFAULT_GDPB_XLOG_PAGE_SIZE, 1024 * 1024);
         TEST_RESULT_BOOL(bufEq(wal2, result), true, "WAL not the same");
+        TEST_RESULT_LOG("P00   WARN: 0/8000000 - Missing previous WAL file. Is current file is first in the chain?");
 
         HRN_STORAGE_REMOVE(
             storageRepoWrite(),
@@ -1066,8 +1072,9 @@ testRun(void)
         insertXRecord(wal2, record, INCOMPLETE_RECORD, .segno = 1);
 
         fillLastPage(wal2, DEFAULT_GDPB_XLOG_PAGE_SIZE);
-        TEST_ERROR(
-            testFilter(filter, wal2, bufSize(wal2), bufSize(wal2)), FormatError, "The file with the end of the 0/7ff0 record is missing");
+        result = testFilter(filter, wal2, bufSize(wal2), bufSize(wal2));
+        TEST_RESULT_BOOL(bufEq(wal2, result), true, "WAL not the same");
+        TEST_RESULT_LOG("P00   WARN: The file with the end of the 0/7ff0 record is missing. Has the timeline switch happened?");
 
         MEM_CONTEXT_TEMP_END();
 
@@ -1150,9 +1157,9 @@ testRun(void)
         insertXRecord(wal2, record, INCOMPLETE_RECORD, .segno = 2);
 
         fillLastPage(wal2, DEFAULT_GDPB_XLOG_PAGE_SIZE);
-        TEST_ERROR(
-            testFilter(filter, wal2, bufSize(wal2), bufSize(wal2)),
-            FormatError, "The file with the end of the 0/8007fe0 record is missing");
+        result = testFilter(filter, wal2, bufSize(wal2), bufSize(wal2));
+        TEST_RESULT_BOOL(bufEq(wal2, result), true, "WAL not the same");
+        TEST_RESULT_LOG("P00   WARN: The file with the end of the 0/8007fe0 record is missing. Has the timeline switch happened?");
 
         HRN_STORAGE_REMOVE(
             storageRepoWrite(),


### PR DESCRIPTION
In the case when the next file is on a different timeline, we could fall with
the error "The file with the end of the LSN record is missing", but in this
case, the absence of the next file is not an error. Because the unfinished
record at the end of the current file will be overwritten at the beginning of
the next one. If the next file is really not in the archive, gpdb will catch
this error when trying to request that file.

Fix this by replacing the error with a warning and writing the unfinished record
as is.
The case of missing the previous file is already being handled, so just add a
warning.