### PR TITLE
ADBM-2458: Fix the handling of WAL records larger than the WAL segment

### DIFF
--- a/src/common/walFilter/walFilter.c
+++ b/src/common/walFilter/walFilter.c
@@ -532,12 +532,7 @@ walFilterProcess(THIS_VOID, const Buffer *const input, Buffer *const output)
         // We have an incomplete record at the end, and we have already read something
         if (this->currentStep != noStep && this->currentStep != stepBeginOfRecord)
         {
-            TRY_BEGIN()
             getEndOfRecord(this);
-            CATCH_ANY()
-            {
-            }
-            TRY_END();
             if (this->record->xl_tot_len == this->gotLen)
             {
                 this->walInterface.xLogRecordFilter(this->record);

--- a/src/common/walFilter/walFilter.c
+++ b/src/common/walFilter/walFilter.c
@@ -425,11 +425,11 @@ readBeginOfRecord(WalFilterState *const this)
     // There may be an unfinished record from the previous file at the beginning of the file. Just skip it.
     while (true)
     {
-#ifdef DEBUG
-        bool ret =
-#endif
-        getNextPage(this, buffer);
-        ASSERT(ret);
+        if (!getNextPage(this, buffer))
+        {
+            goto end;
+        }
+
         if (!(this->currentPageHeader->xlp_info & XLP_FIRST_IS_CONTRECORD) ||
             this->currentPageHeader->xlp_info & XLP_FIRST_IS_OVERWRITE_CONTRECORD)
         {
@@ -488,7 +488,8 @@ getEndOfRecord(WalFilterState *const this)
     {
         if (ioReadEof(storageReadIo(storageRead)))
         {
-            THROW_FMT(FormatError, "%s - Unexpected WAL end", strZ(pgLsnToStr(this->recPtr)));
+            getEndOfRecord(this);
+            break;
         }
 
         bufUsedZero(buffer);

--- a/src/common/walFilter/walFilter.c
+++ b/src/common/walFilter/walFilter.c
@@ -473,47 +473,38 @@ getEndOfRecord(WalFilterState *const this)
 {
     MEM_CONTEXT_TEMP_BEGIN();
 
-    const StorageRead *const storageRead = getNearWal(this, true);
+    ReadRecordStatus result = ReadRecordNeedBuffer;
 
-    if (storageRead == NULL)
+    while (result != ReadRecordSuccess)
     {
-        LOG_WARN_FMT(
-            "The file with the end of the %s record is missing. Has the timeline switch happened?", strZ(pgLsnToStr(this->recPtr)));
-        goto end;
-    }
+        const StorageRead *const storageRead = getNearWal(this, true);
 
-    ioReadOpen(storageReadIo(storageRead));
-
-    Buffer *const buffer = bufNew(this->walPageSize);
-    size_t size = ioRead(storageReadIo(storageRead), buffer);
-    bufUsedSet(buffer, size);
-    while (readRecord(this, buffer) == ReadRecordNeedBuffer)
-    {
-        if (ioReadEof(storageReadIo(storageRead)))
+        if (storageRead == NULL)
         {
-            // We need the data from the header to calculate the name of the next file. Let's keep the header in a longer-lived
-            // context.
-            MEM_CONTEXT_OBJ_BEGIN(this);
-            XLogPageHeaderData *tmpHeader = memNew(SizeOfXLogShortPHD);
-            *tmpHeader = *this->currentPageHeader;
-            this->currentPageHeader = tmpHeader;
-            MEM_CONTEXT_OBJ_END();
-
-            // We need to switch the context before entering recursion, since the number of nesting temporary memory contexts is
-            // limited.
-            ioReadClose(storageReadIo(storageRead));
-            memContextSwitchBack();
-            memContextDiscard();
-
-            getEndOfRecord(this);
-            return;
+            LOG_WARN_FMT(
+                "The file with the end of the %s record is missing. Has the timeline switch happened?",
+                strZ(pgLsnToStr(this->recPtr)));
+            goto end;
         }
 
-        bufUsedZero(buffer);
-        size = ioRead(storageReadIo(storageRead), buffer);
+        ioReadOpen(storageReadIo(storageRead));
+
+        Buffer *const buffer = bufNew(this->walPageSize);
+        size_t size = ioRead(storageReadIo(storageRead), buffer);
         bufUsedSet(buffer, size);
+        while ((result = readRecord(this, buffer)) == ReadRecordNeedBuffer)
+        {
+            if (ioReadEof(storageReadIo(storageRead)))
+            {
+                break;
+            }
+
+            bufUsedZero(buffer);
+            size = ioRead(storageReadIo(storageRead), buffer);
+            bufUsedSet(buffer, size);
+        }
+        ioReadClose(storageReadIo(storageRead));
     }
-    ioReadClose(storageReadIo(storageRead));
 end:
     MEM_CONTEXT_TEMP_END();
 }
@@ -541,7 +532,12 @@ walFilterProcess(THIS_VOID, const Buffer *const input, Buffer *const output)
         // We have an incomplete record at the end, and we have already read something
         if (this->currentStep != noStep && this->currentStep != stepBeginOfRecord)
         {
+            TRY_BEGIN()
             getEndOfRecord(this);
+            CATCH_ANY()
+            {
+            }
+            TRY_END();
             if (this->record->xl_tot_len == this->gotLen)
             {
                 this->walInterface.xLogRecordFilter(this->record);

--- a/src/common/walFilter/walFilter.c
+++ b/src/common/walFilter/walFilter.c
@@ -488,8 +488,22 @@ getEndOfRecord(WalFilterState *const this)
     {
         if (ioReadEof(storageReadIo(storageRead)))
         {
+            // We need the data from the header to calculate the name of the next file. Let's keep the header in a longer-lived
+            // context.
+            MEM_CONTEXT_OBJ_BEGIN(this);
+            XLogPageHeaderData *tmpHeader = memNew(SizeOfXLogShortPHD);
+            *tmpHeader = *this->currentPageHeader;
+            this->currentPageHeader = tmpHeader;
+            MEM_CONTEXT_OBJ_END();
+
+            // We need to switch the context before entering recursion, since the number of nesting temporary memory contexts is
+            // limited.
+            ioReadClose(storageReadIo(storageRead));
+            memContextSwitchBack();
+            memContextDiscard();
+
             getEndOfRecord(this);
-            break;
+            return;
         }
 
         bufUsedZero(buffer);
@@ -518,9 +532,6 @@ walFilterProcess(THIS_VOID, const Buffer *const input, Buffer *const output)
     // Avoid creating local variables before the record is fully read,
     // since if the input buffer is exhausted, we can exit the function.
 
-    if (this->isReadOrphanedData)
-        goto readOrphanedData;
-
     if (input == NULL)
     {
         // We have an incomplete record at the end, and we have already read something
@@ -536,6 +547,9 @@ walFilterProcess(THIS_VOID, const Buffer *const input, Buffer *const output)
         this->done = true;
         goto end;
     }
+
+    if (this->isReadOrphanedData)
+        goto readOrphanedData;
 
     if (this->isBegin)
     {

--- a/test/src/module/common/walFilterGPDB6Test.c
+++ b/test/src/module/common/walFilterGPDB6Test.c
@@ -1274,7 +1274,7 @@ testRun(void)
             STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000002-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd");
         MEM_CONTEXT_TEMP_END();
 
-        TEST_TITLE("Unexpected WAL end");
+        TEST_TITLE("missing next file");
         MEM_CONTEXT_TEMP_BEGIN();
         filter = walFilterNew(pgControl, &archiveInfo);
         {

--- a/test/src/module/common/walFilterGPDB6Test.c
+++ b/test/src/module/common/walFilterGPDB6Test.c
@@ -1297,18 +1297,20 @@ testRun(void)
                 wal1);
         }
 
-        wal2 = bufNew(1024 * 1024);
+        wal2 = bufNew(DEFAULT_GDPB_XLOG_PAGE_SIZE);
         // Subtract SizeOfXLogRecord twice to leave exactly space at the end of the page for the header of the next record.
         record = createXRecord(
             RM_XLOG_ID,
             XLOG_NOOP,
             .body_size = DEFAULT_GDPB_XLOG_PAGE_SIZE - SizeOfXLogLongPHD - SizeOfXLogRecordGPDB6 - SizeOfXLogRecordGPDB6);
-        insertXRecord(wal2, record, NO_FLAGS, .segno = 1);
+        insertXRecord(wal2, record, NO_FLAGS, .segno = 1, .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE);
         record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = (DEFAULT_GDPB_XLOG_PAGE_SIZE * 2) - SizeOfXLogRecordGPDB6);
-        insertXRecord(wal2, record, INCOMPLETE_RECORD, .segno = 1);
+        insertXRecord(wal2, record, INCOMPLETE_RECORD, .segno = 1, .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE);
 
         fillLastPage(wal2, DEFAULT_GDPB_XLOG_PAGE_SIZE);
-        TEST_ERROR(testFilter(filter, wal2, bufSize(wal2), bufSize(wal2)), FormatError, "The file with the end of the 0/4007fe0 record is missing");
+        result = testFilter(filter, wal2, bufSize(wal2), bufSize(wal2));
+        TEST_RESULT_BOOL(bufEq(wal2, result), true, "WAL not the same");
+        TEST_RESULT_LOG("P00   WARN: The file with the end of the 0/ffe0 record is missing. Has the timeline switch happened?");
 
         HRN_STORAGE_REMOVE(
             storageRepoWrite(),

--- a/test/src/module/common/walFilterGPDB6Test.c
+++ b/test/src/module/common/walFilterGPDB6Test.c
@@ -131,12 +131,17 @@ testGetRelfilenode(uint8_t rmid, uint8_t info, bool expect_not_skip)
 static uint32
 getRemainingLenOnPage(XLogRecordBase *record, uint32 targetPage, uint32 segSize, XLogRecPtr recPtr)
 {
+    if (targetPage == 1)
+    {
+        return 0;
+    }
+
     uint32 leftLen = record->xl_tot_len;
     uint32 pageOffset = recPtr % DEFAULT_GDPB_XLOG_PAGE_SIZE;
     uint32 pageN = 0;
     while (pageN != targetPage - 1)
     {
-        uint32 spaceOnPage = DEFAULT_GDPB_XLOG_PAGE_SIZE;
+        uint32 spaceOnPage = DEFAULT_GDPB_XLOG_PAGE_SIZE - recPtr % DEFAULT_GDPB_XLOG_PAGE_SIZE;
         if (pageOffset == 0)
         {
             if (recPtr % segSize == 0)
@@ -1358,83 +1363,130 @@ testRun(void)
         MEM_CONTEXT_TEMP_BEGIN();
         PgControl testPgControl = pgControl;
         testPgControl.walSegmentSize = DEFAULT_GDPB_XLOG_PAGE_SIZE * 2;
-        Buffer *wal1 = bufNew(DEFAULT_GDPB_XLOG_PAGE_SIZE * 2);
-        Buffer *wal2 = bufNew(DEFAULT_GDPB_XLOG_PAGE_SIZE * 2);
-        Buffer *wal3 = bufNew(DEFAULT_GDPB_XLOG_PAGE_SIZE * 2);
-        record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = DEFAULT_GDPB_XLOG_PAGE_SIZE * 4);
+        Buffer *wals[] = {
+            bufNew(DEFAULT_GDPB_XLOG_PAGE_SIZE * 2),
+            bufNew(DEFAULT_GDPB_XLOG_PAGE_SIZE * 2),
+            bufNew(DEFAULT_GDPB_XLOG_PAGE_SIZE * 2),
+            bufNew(DEFAULT_GDPB_XLOG_PAGE_SIZE * 2),
+            bufNew(DEFAULT_GDPB_XLOG_PAGE_SIZE * 2)
+        };
 
+        record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = DEFAULT_GDPB_XLOG_PAGE_SIZE * 9);
+
+        for (uint32 i = 0; i < LENGTH_OF(wals) - 1; i++)
         {
             insertXRecord(
-                wal1,
+                wals[i],
                 record,
                 INCOMPLETE_RECORD,
+                .beginOffset = getRemainingLenOnPage(record, i * 2 + 1, DEFAULT_GDPB_XLOG_PAGE_SIZE * 2, 0),
                 .incompletePosition = 1,
-                .segno = 1,
+                .segno = i + 1,
                 .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE * 2);
+            String *walName = strNewFmt(
+                STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/%s-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
+                strZ(xLogFileName(1, i + 1, DEFAULT_GDPB_XLOG_PAGE_SIZE * 2)));
             HRN_STORAGE_PUT(
                 storageRepoWrite(),
-                STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000001-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
-                wal1);
+                strZ(walName),
+                wals[i]);
         }
 
+        insertXRecord(
+            wals[4],
+            record,
+            NO_FLAGS,
+            .beginOffset = getRemainingLenOnPage(record, 9, DEFAULT_GDPB_XLOG_PAGE_SIZE * 2, 0),
+            .segno = 5,
+            .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE * 2);
+        insertWalSwitchXRecord(wals[4]);
+        fillLastPage(wals[4], DEFAULT_GDPB_XLOG_PAGE_SIZE);
+        HRN_STORAGE_PUT(
+            storageRepoWrite(),
+            STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000005-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
+            wals[4]);
+
+        for (uint32 i = 0; i < LENGTH_OF(wals); i++)
+        {
+            filter = walFilterNew(testPgControl, &archiveInfo);
+            result = testFilter(filter, wals[i], bufSize(wals[i]), bufSize(wals[i]));
+            TEST_RESULT_BOOL(bufEq(wals[i], result), true, "WAL not the same");
+        }
+
+        for (uint32 i = 0; i < LENGTH_OF(wals); i++)
+        {
+            String *walName = strNewFmt(
+                STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/%s-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
+                strZ(xLogFileName(1, i + 1, DEFAULT_GDPB_XLOG_PAGE_SIZE * 2)));
+            HRN_STORAGE_REMOVE(storageRepoWrite(), strZ(walName));
+        }
+        MEM_CONTEXT_TEMP_END();
+
+        TEST_TITLE("read 64 next WAL files");
+        MEM_CONTEXT_TEMP_BEGIN();
+
+        // The maximum size of XLogRecord is 4 GB. Which, with a WAL segment size of 64 MB, gives somewhere between 64-65 file
+        // segments to store the maximum size record.
+        // In order not to create 4 GB of files during the tests, we simulate the same number of WAL files, but of a smaller size.
+        PgControl testPgControl = pgControl;
+        testPgControl.walSegmentSize = DEFAULT_GDPB_XLOG_PAGE_SIZE * 2;
+
+        Buffer *wals[65];
+        for (uint32 i = 0; i < LENGTH_OF(wals); i++)
+        {
+            Buffer *wal = bufNew(DEFAULT_GDPB_XLOG_PAGE_SIZE * 2);
+            wals[i] = wal;
+        }
+        record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = DEFAULT_GDPB_XLOG_PAGE_SIZE * 128);
+
+        for (uint32 i = 0; i < LENGTH_OF(wals) - 1; i++)
         {
             insertXRecord(
-                wal2,
+                wals[i],
                 record,
                 INCOMPLETE_RECORD,
-                .beginOffset = getRemainingLenOnPage(record, 3, DEFAULT_GDPB_XLOG_PAGE_SIZE * 2, 0),
+                .beginOffset = getRemainingLenOnPage(record, i * 2 + 1, DEFAULT_GDPB_XLOG_PAGE_SIZE * 2, 0),
                 .incompletePosition = 1,
-                .segno = 2,
+                .segno = i + 1,
                 .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE * 2);
+
+            String *walName = strNewFmt(
+                STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/%s-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
+                strZ(xLogFileName(1, i + 1, DEFAULT_GDPB_XLOG_PAGE_SIZE * 2)));
             HRN_STORAGE_PUT(
                 storageRepoWrite(),
-                STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000002-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
-                wal2);
+                strZ(walName),
+                wals[i]);
         }
 
-        {
-            insertXRecord(
-                wal3,
-                record,
-                NO_FLAGS,
-                .beginOffset = getRemainingLenOnPage(record, 5, DEFAULT_GDPB_XLOG_PAGE_SIZE * 2, 0),
-                .segno = 3,
-                .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE * 2);
-            insertWalSwitchXRecord(wal3);
-            fillLastPage(wal3, DEFAULT_GDPB_XLOG_PAGE_SIZE);
-            HRN_STORAGE_PUT(
-                storageRepoWrite(),
-                STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000003-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
-                wal3);
-        }
+        insertXRecord(
+            wals[64],
+            record,
+            NO_FLAGS,
+            .beginOffset = getRemainingLenOnPage(record, 129, DEFAULT_GDPB_XLOG_PAGE_SIZE * 2, 0),
+            .segno = LENGTH_OF(wals) - 1,
+            .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE * 2);
+        insertWalSwitchXRecord(wals[64]);
+        fillLastPage(wals[64], DEFAULT_GDPB_XLOG_PAGE_SIZE);
+        HRN_STORAGE_PUT(
+            storageRepoWrite(),
+            STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000041-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
+            wals[64]);
 
+        for (uint32 i = 0; i < LENGTH_OF(wals); i++)
         {
             filter = walFilterNew(testPgControl, &archiveInfo);
-            result = testFilter(filter, wal1, bufSize(wal1), bufSize(wal1));
-            TEST_RESULT_BOOL(bufEq(wal1, result), true, "WAL not the same");
+            result = testFilter(filter, wals[i], bufSize(wals[i]), bufSize(wals[i]));
+            TEST_RESULT_BOOL(bufEq(wals[i], result), true, "WAL not the same");
         }
 
+        for (uint32 i = 0; i < LENGTH_OF(wals); i++)
         {
-            filter = walFilterNew(testPgControl, &archiveInfo);
-            result = testFilter(filter, wal2, bufSize(wal2), bufSize(wal2));
-            TEST_RESULT_BOOL(bufEq(wal2, result), true, "WAL not the same");
+            String *walName = strNewFmt(
+                STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/%s-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
+                strZ(xLogFileName(1, i + 1, DEFAULT_GDPB_XLOG_PAGE_SIZE * 2)));
+            HRN_STORAGE_REMOVE(storageRepoWrite(), strZ(walName));
         }
-
-        {
-            filter = walFilterNew(testPgControl, &archiveInfo);
-            result = testFilter(filter, wal3, bufSize(wal3), bufSize(wal3));
-            TEST_RESULT_BOOL(bufEq(wal3, result), true, "WAL not the same");
-        }
-
-        HRN_STORAGE_REMOVE(
-            storageRepoWrite(),
-            STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000001-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd");
-        HRN_STORAGE_REMOVE(
-            storageRepoWrite(),
-            STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000002-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd");
-        HRN_STORAGE_REMOVE(
-            storageRepoWrite(),
-            STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000003-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd");
 
         MEM_CONTEXT_TEMP_END();
 

--- a/test/src/module/common/walFilterGPDB6Test.c
+++ b/test/src/module/common/walFilterGPDB6Test.c
@@ -1274,7 +1274,7 @@ testRun(void)
             STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000002-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd");
         MEM_CONTEXT_TEMP_END();
 
-        TEST_TITLE("missing next file");
+        TEST_TITLE("absent of end of record");
         MEM_CONTEXT_TEMP_BEGIN();
         filter = walFilterNew(pgControl, &archiveInfo);
         {

--- a/test/src/module/common/walFilterGPDB6Test.c
+++ b/test/src/module/common/walFilterGPDB6Test.c
@@ -1274,7 +1274,7 @@ testRun(void)
             STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000002-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd");
         MEM_CONTEXT_TEMP_END();
 
-        TEST_TITLE("absent of end of record");
+        TEST_TITLE("absent of the end of record");
         MEM_CONTEXT_TEMP_BEGIN();
         filter = walFilterNew(pgControl, &archiveInfo);
         {

--- a/test/src/module/common/walFilterGPDB6Test.c
+++ b/test/src/module/common/walFilterGPDB6Test.c
@@ -128,6 +128,37 @@ testGetRelfilenode(uint8_t rmid, uint8_t info, bool expect_not_skip)
     memFree(record);
 }
 
+static uint32
+getRemainingLenOnPage(XLogRecordBase *record, uint32 targetPage, uint32 segSize, XLogRecPtr recPtr)
+{
+    uint32 leftLen = record->xl_tot_len;
+    uint32 pageOffset = recPtr % DEFAULT_GDPB_XLOG_PAGE_SIZE;
+    uint32 pageN = 0;
+    while (pageN != targetPage - 1)
+    {
+        uint32 spaceOnPage = DEFAULT_GDPB_XLOG_PAGE_SIZE;
+        if (pageOffset == 0)
+        {
+            if (recPtr % segSize == 0)
+            {
+                spaceOnPage -= (uint32) SizeOfXLogLongPHD;
+                recPtr += SizeOfXLogLongPHD;
+            }
+            else
+            {
+                spaceOnPage -= (uint32) SizeOfXLogShortPHD;
+                recPtr += SizeOfXLogShortPHD;
+            }
+        }
+        leftLen -= spaceOnPage;
+        recPtr += spaceOnPage;
+        pageN++;
+        pageOffset = 0;
+    }
+
+    return leftLen;
+}
+
 /***********************************************************************************************************************************
 Test Run
 ***********************************************************************************************************************************/
@@ -1265,7 +1296,7 @@ testRun(void)
         insertXRecord(wal2, record, INCOMPLETE_RECORD, .segno = 1);
 
         fillLastPage(wal2, DEFAULT_GDPB_XLOG_PAGE_SIZE);
-        TEST_ERROR(testFilter(filter, wal2, bufSize(wal2), bufSize(wal2)), FormatError, "0/4007fe0 - Unexpected WAL end");
+        TEST_ERROR(testFilter(filter, wal2, bufSize(wal2), bufSize(wal2)), FormatError, "The file with the end of the 0/4007fe0 record is missing");
 
         HRN_STORAGE_REMOVE(
             storageRepoWrite(),
@@ -1320,6 +1351,91 @@ testRun(void)
         HRN_STORAGE_REMOVE(
             storageRepoWrite(),
             STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000002-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd");
+        MEM_CONTEXT_TEMP_END();
+
+        TEST_TITLE("WAL record larger then WAL segment");
+        // Test case when single WAL record is larger than WAL segment
+        MEM_CONTEXT_TEMP_BEGIN();
+        PgControl testPgControl = pgControl;
+        testPgControl.walSegmentSize = DEFAULT_GDPB_XLOG_PAGE_SIZE * 2;
+        Buffer *wal1 = bufNew(DEFAULT_GDPB_XLOG_PAGE_SIZE * 2);
+        Buffer *wal2 = bufNew(DEFAULT_GDPB_XLOG_PAGE_SIZE * 2);
+        Buffer *wal3 = bufNew(DEFAULT_GDPB_XLOG_PAGE_SIZE * 2);
+        record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = DEFAULT_GDPB_XLOG_PAGE_SIZE * 4);
+
+        {
+            insertXRecord(
+                wal1,
+                record,
+                INCOMPLETE_RECORD,
+                .incompletePosition = 1,
+                .segno = 1,
+                .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE * 2);
+            HRN_STORAGE_PUT(
+                storageRepoWrite(),
+                STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000001-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
+                wal1);
+        }
+
+        {
+            insertXRecord(
+                wal2,
+                record,
+                INCOMPLETE_RECORD,
+                .beginOffset = getRemainingLenOnPage(record, 3, DEFAULT_GDPB_XLOG_PAGE_SIZE * 2, 0),
+                .incompletePosition = 1,
+                .segno = 2,
+                .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE * 2);
+            HRN_STORAGE_PUT(
+                storageRepoWrite(),
+                STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000002-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
+                wal2);
+        }
+
+        {
+            insertXRecord(
+                wal3,
+                record,
+                NO_FLAGS,
+                .beginOffset = getRemainingLenOnPage(record, 5, DEFAULT_GDPB_XLOG_PAGE_SIZE * 2, 0),
+                .segno = 3,
+                .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE * 2);
+            insertWalSwitchXRecord(wal3);
+            fillLastPage(wal3, DEFAULT_GDPB_XLOG_PAGE_SIZE);
+            HRN_STORAGE_PUT(
+                storageRepoWrite(),
+                STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000003-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
+                wal3);
+        }
+
+        {
+            filter = walFilterNew(testPgControl, &archiveInfo);
+            result = testFilter(filter, wal1, bufSize(wal1), bufSize(wal1));
+            TEST_RESULT_BOOL(bufEq(wal1, result), true, "WAL not the same");
+        }
+
+        {
+            filter = walFilterNew(testPgControl, &archiveInfo);
+            result = testFilter(filter, wal2, bufSize(wal2), bufSize(wal2));
+            TEST_RESULT_BOOL(bufEq(wal2, result), true, "WAL not the same");
+        }
+
+        {
+            filter = walFilterNew(testPgControl, &archiveInfo);
+            result = testFilter(filter, wal3, bufSize(wal3), bufSize(wal3));
+            TEST_RESULT_BOOL(bufEq(wal3, result), true, "WAL not the same");
+        }
+
+        HRN_STORAGE_REMOVE(
+            storageRepoWrite(),
+            STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000001-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd");
+        HRN_STORAGE_REMOVE(
+            storageRepoWrite(),
+            STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000002-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd");
+        HRN_STORAGE_REMOVE(
+            storageRepoWrite(),
+            STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000003-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd");
+
         MEM_CONTEXT_TEMP_END();
 
         TEST_TITLE("compressed and encrypted WAL file");


### PR DESCRIPTION
The WAL file format in Postgres allows the creation of WAL records up to 4 GB
in size. Although the existence of such large records is theoretical in
practice, it would not be superfluous to support such records.

This patch adds the ability to read more than one file to fully read an
unfinished record at the end of the file. It also fixed the handling of the
situation when the entire previous file is a continuation of the record from the
file before last, in which case we write such an record as is.