### PR TITLE
ADBM-2468: Fix reading the end of a record when the next file is partial

### DIFF
--- a/src/common/walFilter/walFilter.c
+++ b/src/common/walFilter/walFilter.c
@@ -532,7 +532,11 @@ walFilterProcess(THIS_VOID, const Buffer *const input, Buffer *const output)
         // We have an incomplete record at the end, and we have already read something
         if (this->currentStep != noStep && this->currentStep != stepBeginOfRecord)
         {
+            TRY_BEGIN()
             getEndOfRecord(this);
+            CATCH_ANY()
+            LOG_WARN_FMT("Error when reading the end of a record from the next file: %s", errorMessage());
+            TRY_END();
             if (this->record->xl_tot_len == this->gotLen)
             {
                 this->walInterface.xLogRecordFilter(this->record);


### PR DESCRIPTION
When there is an unfinished record at the end of the file, the next file may be
partial if the timeline was switched during its writing. Then the end of the
record may not be fully written. In this case, we will start reading garbage at
some point, which will lead to an error.

Fix this by wrapping the getEndOfRecord call in try/catch and replacing the
error with a warning and writing the record as is.