### PR TITLE
ADBM-2449: Add support for XLOG_PENDING_DELETE and XLOG_SMGR_CREATE_PDL WAL records

### DIFF
--- a/arenadata/scripts/test_partial_restore.sh
+++ b/arenadata/scripts/test_partial_restore.sh
@@ -99,8 +99,9 @@ done
 
 # Create new tables and add data to existing ones.
 psql -c "create table t3 (a int, b int[128]) distributed by(a);"
-psql -c "create table t6 (a int, b int[128]) with (appendoptimized=true) distributed by(a);"
-psql -c "create table t9 (a int, b int[128]) with (appendoptimized=true, orientation=column) distributed by(a);"
+# Add several checkpoints inside the transaction to test the pending delete records.
+psql -c "begin; create table t6 (a int, b int[128]) with (appendoptimized=true) distributed by(a); checkpoint; commit;"
+psql -c "begin; create table t9 (a int, b int[128]) with (appendoptimized=true, orientation=column) distributed by(a); checkpoint; commit;"
 psql -c "insert into t3 select a, (select * from random_array) from generate_series(1, 100000)a;"
 psql -c "insert into t6 select a, (select * from random_array) from generate_series(1, 100000)a;"
 psql -c "insert into t9 select a, (select * from random_array) from generate_series(1, 100000)a;"

--- a/src/common/walFilter/postgresCommon.h
+++ b/src/common/walFilter/postgresCommon.h
@@ -150,10 +150,12 @@ enum
     XLOG_FPI =                  0xA0,
     XLOG_NEXTRELFILENODE =      0xB0,
     XLOG_OVERWRITE_CONTRECORD = 0xC0,
+    XLOG_PENDING_DELETE =       0xD0,
 
 // storage
-    XLOG_SMGR_CREATE =    0x10,
-    XLOG_SMGR_TRUNCATE =  0x20,
+    XLOG_SMGR_CREATE =     0x10,
+    XLOG_SMGR_TRUNCATE =   0x20,
+    XLOG_SMGR_CREATE_PDL = 0x30,
 
 // heap
     XLOG_HEAP2_REWRITE =      0x00,

--- a/src/common/walFilter/versions/recordProcessGPDB6.c
+++ b/src/common/walFilter/versions/recordProcessGPDB6.c
@@ -459,12 +459,11 @@ filterRecordGPDB6(XLogRecordBase *const recordBase)
 
     XLogRecordGPDB6 *const record = (XLogRecordGPDB6 *const) recordBase;
 
-    if (record->xl_rmid != RM_XLOG_ID || (record->xl_info & ~XLR_INFO_MASK) != XLOG_PENDING_DELETE)
-    {
-        const RelFileNode *const node = getRelFileNode(record);
+    const RelFileNode *const node = getRelFileNode(record);
 
-        if (node == NULL || isRelationNeeded(node->dbNode, node->spcNode, node->relNode))
-            return;
+    if (node == NULL || isRelationNeeded(node->dbNode, node->spcNode, node->relNode))
+    {
+        return;
     }
 
     record->xl_rmid = RM_XLOG_ID;

--- a/src/common/walFilter/versions/recordProcessGPDB6.c
+++ b/src/common/walFilter/versions/recordProcessGPDB6.c
@@ -459,12 +459,12 @@ filterRecordGPDB6(XLogRecordBase *const recordBase)
 
     XLogRecordGPDB6 *const record = (XLogRecordGPDB6 *const) recordBase;
 
-    const RelFileNode *const node = getRelFileNode(record);
-
-    if ((node == NULL || isRelationNeeded(node->dbNode, node->spcNode, node->relNode)) &&
-        !(record->xl_rmid == RM_XLOG_ID && (record->xl_info & ~XLR_INFO_MASK) == XLOG_PENDING_DELETE))
+    if (record->xl_rmid != RM_XLOG_ID || (record->xl_info & ~XLR_INFO_MASK) != XLOG_PENDING_DELETE)
     {
-        return;
+        const RelFileNode *const node = getRelFileNode(record);
+
+        if (node == NULL || isRelationNeeded(node->dbNode, node->spcNode, node->relNode))
+            return;
     }
 
     record->xl_rmid = RM_XLOG_ID;

--- a/src/common/walFilter/versions/recordProcessGPDB6.c
+++ b/src/common/walFilter/versions/recordProcessGPDB6.c
@@ -54,6 +54,7 @@ getXlog(const XLogRecordGPDB6 *record)
         case XLOG_END_OF_RECOVERY:
         case XLOG_OVERWRITE_CONTRECORD:
         case XLOG_SWITCH:
+        case XLOG_PENDING_DELETE:
 //          ignore
             return NULL;
 
@@ -72,6 +73,7 @@ getStorage(const XLogRecordGPDB6 *record)
     switch (info)
     {
         case XLOG_SMGR_CREATE:
+        case XLOG_SMGR_CREATE_PDL:
             return (const RelFileNode *) XLogRecGetData(record);
 
         case XLOG_SMGR_TRUNCATE:
@@ -459,7 +461,8 @@ filterRecordGPDB6(XLogRecordBase *const recordBase)
 
     const RelFileNode *const node = getRelFileNode(record);
 
-    if (node == NULL || isRelationNeeded(node->dbNode, node->spcNode, node->relNode))
+    if ((node == NULL || isRelationNeeded(node->dbNode, node->spcNode, node->relNode)) &&
+        !(record->xl_rmid == RM_XLOG_ID && (record->xl_info & ~XLR_INFO_MASK) == XLOG_PENDING_DELETE))
     {
         return;
     }

--- a/test/src/module/common/walFilterGPDB6Test.c
+++ b/test/src/module/common/walFilterGPDB6Test.c
@@ -2946,7 +2946,7 @@ testRun(void)
                 {RM_XLOG_ID, XLOG_NOOP,        sizeof(RelFileNode), &nodes[8]},
                 {RM6_HEAP_ID, XLOG_HEAP_INSERT, sizeof(RelFileNode), &nodes[9]},
                 {RM6_HEAP_ID, XLOG_HEAP_INSERT, sizeof(RelFileNode), &nodes[10]},
-                {RM_XLOG_ID, XLOG_NOOP,        100,                  NULL},
+                {RM_XLOG_ID,  XLOG_PENDING_DELETE, 100,              NULL},
             };
 
             buildWalP(wal, records, LENGTH_OF(records), 0);

--- a/test/src/module/common/walFilterGPDB6Test.c
+++ b/test/src/module/common/walFilterGPDB6Test.c
@@ -2197,15 +2197,17 @@ testRun(void)
         testGetRelfilenode(RM_XLOG_ID, XLOG_RESTORE_POINT, false);
         testGetRelfilenode(RM_XLOG_ID, XLOG_FPW_CHANGE, false);
         testGetRelfilenode(RM_XLOG_ID, XLOG_END_OF_RECOVERY, false);
+        testGetRelfilenode(RM_XLOG_ID, XLOG_PENDING_DELETE, false);
 
         testGetRelfilenode(RM_XLOG_ID, XLOG_FPI, true);
 
-        record = createXRecord(RM_XLOG_ID, 0xD0, .body_size = 100);
-        TEST_ERROR(getRelFileNode((XLogRecordGPDB6 *) record), FormatError, "XLOG UNKNOWN: 208");
+        record = createXRecord(RM_XLOG_ID, 0xE0, .body_size = 100);
+        TEST_ERROR(getRelFileNode((XLogRecordGPDB6 *) record), FormatError, "XLOG UNKNOWN: 224");
         memFree(record);
 
         TEST_TITLE("Storage");
         testGetRelfilenode(RM6_SMGR_ID, XLOG_SMGR_CREATE, true);
+        testGetRelfilenode(RM6_SMGR_ID, XLOG_SMGR_CREATE_PDL, true);
 
         record = createXRecord(RM6_SMGR_ID, XLOG_SMGR_TRUNCATE, .body_size = 100);
 
@@ -2222,8 +2224,8 @@ testRun(void)
         }
         memFree(record);
 
-        record = createXRecord(RM6_SMGR_ID, 0x30, .body_size = 100);
-        TEST_ERROR(getRelFileNode((XLogRecordGPDB6 *) record), FormatError, "Storage UNKNOWN: 48");
+        record = createXRecord(RM6_SMGR_ID, 0x40, .body_size = 100);
+        TEST_ERROR(getRelFileNode((XLogRecordGPDB6 *) record), FormatError, "Storage UNKNOWN: 64");
         memFree(record);
 
         TEST_TITLE("Heap2");
@@ -2927,6 +2929,7 @@ testRun(void)
                 {RM6_HEAP_ID, XLOG_HEAP_INSERT, sizeof(RelFileNode), &nodes[8]},
                 {RM6_HEAP_ID, XLOG_HEAP_INSERT, sizeof(RelFileNode), &nodes[9]},
                 {RM6_HEAP_ID, XLOG_HEAP_INSERT, sizeof(RelFileNode), &nodes[10]},
+                {RM_XLOG_ID,  XLOG_PENDING_DELETE, 100,              NULL},
             };
 
             XRecordInfo records_expected[] = {
@@ -2943,6 +2946,7 @@ testRun(void)
                 {RM_XLOG_ID, XLOG_NOOP,        sizeof(RelFileNode), &nodes[8]},
                 {RM6_HEAP_ID, XLOG_HEAP_INSERT, sizeof(RelFileNode), &nodes[9]},
                 {RM6_HEAP_ID, XLOG_HEAP_INSERT, sizeof(RelFileNode), &nodes[10]},
+                {RM_XLOG_ID, XLOG_NOOP,        100,                  NULL},
             };
 
             buildWalP(wal, records, LENGTH_OF(records), 0);


### PR DESCRIPTION
Add support for two new types of WAL records: XLOG_PENDING_DELETE and
XLOG_SMGR_CREATE_PDL. XLOG_SMGR_CREATE_PDL records are processed in the same way
as XLOG_SMGR_CREATE. XLOG_PENDING_DELETE records are left as is.