### PR TITLE
ADBM-2477: Remove the assert for uniqueness of the wal file in the archive

### DIFF
--- a/src/common/walFilter/walFilter.c
+++ b/src/common/walFilter/walFilter.c
@@ -386,7 +386,6 @@ getNearWal (WalFilterState *const this, bool isNext)
         return NULL;
     }
 
-    ASSERT(strLstSize(segmentList) == 1);
     const String *walSegment = strLstGet(segmentList, 0);
 
     const bool compressible =


### PR DESCRIPTION
Previously, it was assumed that an archive could not contain both a complete and
a partial file with the same number. But in practice, this turned out not to be
the case.
In the case of the next file, either of the two will be suitable for us, as they
should have the same beginning.
In the case of the previous file, we should not find the partial file.

This patch removes the problematic assert.
