### PR TITLE
ADBM-2478-ci: Improve WAL filtering tests

### DIFF
--- a/arenadata/scripts/helpers/common.sh
+++ b/arenadata/scripts/helpers/common.sh
@@ -1,0 +1,89 @@
+function setup_environment {
+    export PGBACKREST_TEST_DIR=/home/gpadmin/test_pgbackrest
+
+    # Starting up demo cluster
+    source "/usr/local/greenplum-db-devel/greenplum_path.sh"
+    pushd gpdb_src/gpAux/gpdemo
+    make create-demo-cluster WITH_MIRRORS=$2
+    source gpdemo-env.sh
+    popd
+
+    # Creating backup and log directories for pgbackrest
+    export TEST_NAME=$1
+    mkdir -p "$PGBACKREST_TEST_DIR/logs/$TEST_NAME"
+    mkdir -p "$PGBACKREST_TEST_DIR/$TEST_NAME"
+    export DATADIR="${MASTER_DATA_DIRECTORY%*/*/*}"
+    export MASTER=${DATADIR}/qddir/demoDataDir-1
+    export PRIMARY1=${DATADIR}/dbfast1/demoDataDir0
+    export PRIMARY2=${DATADIR}/dbfast2/demoDataDir1
+    export PRIMARY3=${DATADIR}/dbfast3/demoDataDir2
+
+    if [ "$2" = true ]; then
+        export MIRROR1=${DATADIR}/dbfast_mirror1/demoDataDir0
+        export MIRROR2=${DATADIR}/dbfast_mirror2/demoDataDir1
+        export MIRROR3=${DATADIR}/dbfast_mirror3/demoDataDir2
+    fi
+
+    # Filling the pgbackrest.conf configuration file
+    cat <<EOF > /etc/pgbackrest.conf
+[seg-1]
+pg1-path=$MASTER
+pg1-port=$PGPORT
+
+[seg0]
+pg1-path=$PRIMARY1
+pg1-port=$((PGPORT+2))
+
+[seg1]
+pg1-path=$PRIMARY2
+pg1-port=$((PGPORT+3))
+
+[seg2]
+pg1-path=$PRIMARY3
+pg1-port=$((PGPORT+4))
+
+[global]
+repo1-path=$PGBACKREST_TEST_DIR/$TEST_NAME
+log-path=$PGBACKREST_TEST_DIR/logs/$TEST_NAME
+start-fast=y
+fork=GPDB
+EOF
+
+    # Initializing pgbackrest for GPDB
+    for i in -1 0 1 2
+    do
+        PGOPTIONS="-c gp_session_role=utility" pgbackrest --stanza=seg$i stanza-create &
+    done
+    wait
+
+    gpconfig -c archive_mode -v on
+
+    gpconfig -c archive_command -v "'PGOPTIONS=\"-c gp_session_role=utility\" \
+    pgbackrest --stanza=seg%c archive-push %p'" --skipvalidation
+
+    gpstop -ar
+
+    # pgbackrest health check
+    for i in -1 0 1 2
+    do
+        PGOPTIONS="-c gp_session_role=utility" pgbackrest --stanza=seg$i check
+    done
+
+    export PGDATABASE=testdb
+    createdb
+
+    GP_VERSION_NUM=$(pg_config --gp_version | cut -c 11)
+
+    if [ "$GP_VERSION_NUM" -le 6 ]; then
+        psql -c "create extension gp_pitr;"
+        export RESTORE_OPTIONS=""
+        export PYTHON_EXTENSION_NAME="plpythonu"
+    else
+        export RESTORE_OPTIONS="--target-action=promote"
+        export PYTHON_EXTENSION_NAME="plpython3u"
+    fi
+}
+
+function dump_table {
+    psql -Atc "select * from $1 order by a, b;" -o "$PGBACKREST_TEST_DIR/$TEST_NAME/$1_$2.txt"
+}

--- a/arenadata/scripts/helpers/common.sh
+++ b/arenadata/scripts/helpers/common.sh
@@ -1,5 +1,5 @@
 function setup_environment {
-    export PGBACKREST_TEST_DIR=/home/gpadmin/test_pgbackrest
+    export TEST_DIR=/home/gpadmin/test_pgbackrest
 
     # Starting up demo cluster
     source "/usr/local/greenplum-db-devel/greenplum_path.sh"
@@ -10,8 +10,8 @@ function setup_environment {
 
     # Creating backup and log directories for pgbackrest
     export TEST_NAME=$1
-    mkdir -p "$PGBACKREST_TEST_DIR/logs/$TEST_NAME"
-    mkdir -p "$PGBACKREST_TEST_DIR/$TEST_NAME"
+    mkdir -p "$TEST_DIR/logs/$TEST_NAME"
+    mkdir -p "$TEST_DIR/$TEST_NAME"
     export DATADIR="${MASTER_DATA_DIRECTORY%*/*/*}"
     export MASTER=${DATADIR}/qddir/demoDataDir-1
     export PRIMARY1=${DATADIR}/dbfast1/demoDataDir0
@@ -43,8 +43,8 @@ pg1-path=$PRIMARY3
 pg1-port=$((PGPORT+4))
 
 [global]
-repo1-path=$PGBACKREST_TEST_DIR/$TEST_NAME
-log-path=$PGBACKREST_TEST_DIR/logs/$TEST_NAME
+repo1-path=$TEST_DIR/$TEST_NAME
+log-path=$TEST_DIR/logs/$TEST_NAME
 start-fast=y
 fork=GPDB
 EOF
@@ -85,5 +85,5 @@ EOF
 }
 
 function dump_table {
-    psql -Atc "select * from $1 order by a, b;" -o "$PGBACKREST_TEST_DIR/$TEST_NAME/$1_$2.txt"
+    psql -Atc "select * from $1 order by a, b;" -o "$TEST_DIR/$TEST_NAME/$1_$2.txt"
 }

--- a/arenadata/scripts/test_partial_restore.sh
+++ b/arenadata/scripts/test_partial_restore.sh
@@ -85,7 +85,7 @@ dump_table t7 pre &
 dump_table t9 pre &
 wait
 
-psql -c "select * from gp_segment_configuration order by dbid" -o "$PGBACKREST_TEST_DIR/$TEST_NAME/gp_segment_conf_expected.out"
+psql -c "select * from gp_segment_configuration order by dbid" -o "$TEST_DIR/$TEST_NAME/gp_segment_conf_expected.out"
 
 # Step 6
 gpstop -a
@@ -94,10 +94,10 @@ rm -rf "${MIRROR1:?}/"* "${MIRROR2:?}/"* "${MIRROR3:?}/"* "$DATADIR/standby/"*
 
 # Step 7
 # Restore the cluster without data to get metadata
-echo "[]" > "$PGBACKREST_TEST_DIR/$TEST_NAME/empty_filter.json"
+echo "[]" > "$TEST_DIR/$TEST_NAME/empty_filter.json"
 for i in -1 0 1 2
 do
-    pgbackrest --stanza=seg$i --type=name --target=backup1 $RESTORE_OPTIONS --filter="$(realpath "$PGBACKREST_TEST_DIR/$TEST_NAME/empty_filter.json")" restore &
+    pgbackrest --stanza=seg$i --type=name --target=backup1 $RESTORE_OPTIONS --filter="$(realpath "$TEST_DIR/$TEST_NAME/empty_filter.json")" restore &
 done
 wait
 
@@ -123,10 +123,10 @@ $(cat /home/gpadmin/pgbackrest/arenadata/scripts/helpers/partial_restore_helper.
 
 # Step 8
 # Dump metadata
-psql -Atc "select * from table_metadata_dump(\$\$'t1','t3','t4','t6','t7','t9'\$\$)" -o "$PGBACKREST_TEST_DIR/$TEST_NAME/filter_seg-1.json"
-psql -Atc "select table_metadata_dump(\$\$'t1','t3','t4','t6','t7','t9'\$\$) from gp_dist_random(\$\$gp_id\$\$) where gp_segment_id = 0;" -o "$PGBACKREST_TEST_DIR/$TEST_NAME/filter_seg0.json"
-psql -Atc "select table_metadata_dump(\$\$'t1','t3','t4','t6','t7','t9'\$\$) from gp_dist_random(\$\$gp_id\$\$) where gp_segment_id = 1;" -o "$PGBACKREST_TEST_DIR/$TEST_NAME/filter_seg1.json"
-psql -Atc "select table_metadata_dump(\$\$'t1','t3','t4','t6','t7','t9'\$\$) from gp_dist_random(\$\$gp_id\$\$) where gp_segment_id = 2;" -o "$PGBACKREST_TEST_DIR/$TEST_NAME/filter_seg2.json"
+psql -Atc "select * from table_metadata_dump(\$\$'t1','t3','t4','t6','t7','t9'\$\$)" -o "$TEST_DIR/$TEST_NAME/filter_seg-1.json"
+psql -Atc "select table_metadata_dump(\$\$'t1','t3','t4','t6','t7','t9'\$\$) from gp_dist_random(\$\$gp_id\$\$) where gp_segment_id = 0;" -o "$TEST_DIR/$TEST_NAME/filter_seg0.json"
+psql -Atc "select table_metadata_dump(\$\$'t1','t3','t4','t6','t7','t9'\$\$) from gp_dist_random(\$\$gp_id\$\$) where gp_segment_id = 1;" -o "$TEST_DIR/$TEST_NAME/filter_seg1.json"
+psql -Atc "select table_metadata_dump(\$\$'t1','t3','t4','t6','t7','t9'\$\$) from gp_dist_random(\$\$gp_id\$\$) where gp_segment_id = 2;" -o "$TEST_DIR/$TEST_NAME/filter_seg2.json"
 
 # Step 9
 gpstop -a
@@ -136,7 +136,7 @@ rm -rf "${MASTER:?}/"* "${PRIMARY1:?}/"* "${PRIMARY2:?}/"* "${PRIMARY3:?}/"*
 # Restore only tables t1, t3, t4, t6, t7 and t9
 for i in -1 0 1 2
 do
-    pgbackrest --stanza=seg$i --type=name --target=backup1 $RESTORE_OPTIONS --filter="$(realpath "$PGBACKREST_TEST_DIR/$TEST_NAME/filter_seg$i.json")" restore &
+    pgbackrest --stanza=seg$i --type=name --target=backup1 $RESTORE_OPTIONS --filter="$(realpath "$TEST_DIR/$TEST_NAME/filter_seg$i.json")" restore &
 done
 wait
 
@@ -164,12 +164,12 @@ wait
 
 # Step 11
 # Verify data integrity.
-diff "$PGBACKREST_TEST_DIR/$TEST_NAME/t1_pre.txt" "$PGBACKREST_TEST_DIR/$TEST_NAME/t1_after.txt"
-diff "$PGBACKREST_TEST_DIR/$TEST_NAME/t3_pre.txt" "$PGBACKREST_TEST_DIR/$TEST_NAME/t3_after.txt"
-diff "$PGBACKREST_TEST_DIR/$TEST_NAME/t4_pre.txt" "$PGBACKREST_TEST_DIR/$TEST_NAME/t4_after.txt"
-diff "$PGBACKREST_TEST_DIR/$TEST_NAME/t6_pre.txt" "$PGBACKREST_TEST_DIR/$TEST_NAME/t6_after.txt"
-diff "$PGBACKREST_TEST_DIR/$TEST_NAME/t7_pre.txt" "$PGBACKREST_TEST_DIR/$TEST_NAME/t7_after.txt"
-diff "$PGBACKREST_TEST_DIR/$TEST_NAME/t9_pre.txt" "$PGBACKREST_TEST_DIR/$TEST_NAME/t9_after.txt"
+diff "$TEST_DIR/$TEST_NAME/t1_pre.txt" "$TEST_DIR/$TEST_NAME/t1_after.txt"
+diff "$TEST_DIR/$TEST_NAME/t3_pre.txt" "$TEST_DIR/$TEST_NAME/t3_after.txt"
+diff "$TEST_DIR/$TEST_NAME/t4_pre.txt" "$TEST_DIR/$TEST_NAME/t4_after.txt"
+diff "$TEST_DIR/$TEST_NAME/t6_pre.txt" "$TEST_DIR/$TEST_NAME/t6_after.txt"
+diff "$TEST_DIR/$TEST_NAME/t7_pre.txt" "$TEST_DIR/$TEST_NAME/t7_after.txt"
+diff "$TEST_DIR/$TEST_NAME/t9_pre.txt" "$TEST_DIR/$TEST_NAME/t9_after.txt"
 
 # Step 12
 gprecoverseg -aF
@@ -177,5 +177,5 @@ gpinitstandby -as "$HOSTNAME" -S "$DATADIR/standby" -P $((PGPORT+1))
 
 # Step 13
 # Checking cluster configuration after restore
-psql -c "select * from gp_segment_configuration order by dbid" -o "$PGBACKREST_TEST_DIR/$TEST_NAME/gp_segment_conf_result.out"
-diff "$PGBACKREST_TEST_DIR/$TEST_NAME/gp_segment_conf_expected.out" "$PGBACKREST_TEST_DIR/$TEST_NAME/gp_segment_conf_result.out"
+psql -c "select * from gp_segment_configuration order by dbid" -o "$TEST_DIR/$TEST_NAME/gp_segment_conf_result.out"
+diff "$TEST_DIR/$TEST_NAME/gp_segment_conf_expected.out" "$TEST_DIR/$TEST_NAME/gp_segment_conf_result.out"

--- a/arenadata/scripts/test_partial_restore.sh
+++ b/arenadata/scripts/test_partial_restore.sh
@@ -1,13 +1,31 @@
 #!/usr/bin/env bash
 set -exo pipefail
 
+# Test partial restore.
+# The test consists of the following steps:
+#  1. Create tables before backup and filling them with data.
+#  2. Create backup
+#  3. Create tables after backup and fill them with data. These tables and their data are stored in WAL and must be filtered out
+#  during archive-get.
+#  4. Create a restore point and send the WAL to the archive.
+#  5. Saving the contents of the tables on disk.
+#  6. Stop and delete the cluster.
+#  7. Restore only the system catalog.
+#  8. Create a filter file for each segment. The filter contains both tables created before the backup and tables created after.
+#  9. Stop and delete the cluster.
+#  10. Restoring only a specific set of tables.
+#  11. Check the correctness of the restored data.
+#  12. Restore the mirrors.
+#  13. Check the correctness of cluster restoration.
+
 source /home/gpadmin/pgbackrest/arenadata/scripts/helpers/common.sh
 
 setup_environment $(basename "${0%.sh}") true
 
 # The test scenario starts here
 psql -c "create view random_array as select array_agg((random() * 100)::int) from generate_series(1, 128)a;" &
-# Сreate test tables
+# Step 1
+# Create test tables before backup
 psql -c "create table t1 (a int, b int[128]) distributed by(a);" &
 psql -c "create table t2 (a int, b int[128]) distributed by(a);" &
 
@@ -26,13 +44,15 @@ psql -c "insert into t5 select a, (select * from random_array) from generate_ser
 
 wait
 
-# Сreate backup
+# Step 2
+# Create backup
 for i in -1 0 1 2
 do
     PGOPTIONS="-c gp_session_role=utility" pgbackrest --stanza=seg$i --type=full backup &
 done
 wait
 
+# Step 3
 # Create new tables and add data to existing ones.
 psql -c "create table t3 (a int, b int[128]) distributed by(a);" &
 # Add several checkpoints inside the transaction to test the pending delete records.
@@ -51,10 +71,12 @@ psql -c "insert into t7 select a, (select * from random_array) from generate_ser
 psql -c "insert into t8 select a, (select * from random_array) from generate_series(1, 100000)a;" &
 wait
 
+# Step 4
 # Create restore point and send wal files to the archive
 psql -c "select gp_create_restore_point('backup1');"
 psql -c "select gp_switch_wal();"
 
+# Step 5
 dump_table t1 pre &
 dump_table t3 pre &
 dump_table t4 pre &
@@ -65,12 +87,14 @@ wait
 
 psql -c "select * from gp_segment_configuration order by dbid" -o "$PGBACKREST_TEST_DIR/$TEST_NAME/gp_segment_conf_expected.out"
 
+# Step 6
 gpstop -a
 rm -rf "${MASTER:?}/"* "${PRIMARY1:?}/"* "${PRIMARY2:?}/"* "${PRIMARY3:?}/"*
 rm -rf "${MIRROR1:?}/"* "${MIRROR2:?}/"* "${MIRROR3:?}/"* "$DATADIR/standby/"*
 
+# Step 7
 # Restore the cluster without data to get metadata
-echo "[]" >> "$PGBACKREST_TEST_DIR/$TEST_NAME/empty_filter.json"
+echo "[]" > "$PGBACKREST_TEST_DIR/$TEST_NAME/empty_filter.json"
 for i in -1 0 1 2
 do
     pgbackrest --stanza=seg$i --type=name --target=backup1 $RESTORE_OPTIONS --filter="$(realpath "$PGBACKREST_TEST_DIR/$TEST_NAME/empty_filter.json")" restore &
@@ -80,6 +104,7 @@ wait
 gpstart -am
 gpinitstandby -ar
 
+# Mark mirror segments as unavailable
 PGOPTIONS="-c gp_session_role=utility" psql << EOF
 set allow_system_table_mods to true;
 
@@ -96,16 +121,19 @@ psql -c "create or replace function table_metadata_dump (to_dump text) returns t
 $(cat /home/gpadmin/pgbackrest/arenadata/scripts/helpers/partial_restore_helper.py)
 \$\$ language $PYTHON_EXTENSION_NAME"
 
+# Step 8
 # Dump metadata
 psql -Atc "select * from table_metadata_dump(\$\$'t1','t3','t4','t6','t7','t9'\$\$)" -o "$PGBACKREST_TEST_DIR/$TEST_NAME/filter_seg-1.json"
 psql -Atc "select table_metadata_dump(\$\$'t1','t3','t4','t6','t7','t9'\$\$) from gp_dist_random(\$\$gp_id\$\$) where gp_segment_id = 0;" -o "$PGBACKREST_TEST_DIR/$TEST_NAME/filter_seg0.json"
 psql -Atc "select table_metadata_dump(\$\$'t1','t3','t4','t6','t7','t9'\$\$) from gp_dist_random(\$\$gp_id\$\$) where gp_segment_id = 1;" -o "$PGBACKREST_TEST_DIR/$TEST_NAME/filter_seg1.json"
 psql -Atc "select table_metadata_dump(\$\$'t1','t3','t4','t6','t7','t9'\$\$) from gp_dist_random(\$\$gp_id\$\$) where gp_segment_id = 2;" -o "$PGBACKREST_TEST_DIR/$TEST_NAME/filter_seg2.json"
 
+# Step 9
 gpstop -a
 rm -rf "${MASTER:?}/"* "${PRIMARY1:?}/"* "${PRIMARY2:?}/"* "${PRIMARY3:?}/"*
 
-# Restore only tables t1, t3, t3 and t6
+# Step 10
+# Restore only tables t1, t3, t4, t6, t7 and t9
 for i in -1 0 1 2
 do
     pgbackrest --stanza=seg$i --type=name --target=backup1 $RESTORE_OPTIONS --filter="$(realpath "$PGBACKREST_TEST_DIR/$TEST_NAME/filter_seg$i.json")" restore &
@@ -114,6 +142,8 @@ wait
 
 gpstart -am
 gpinitstandby -ar
+
+# Mark mirror segments as unavailable
 PGOPTIONS="-c gp_session_role=utility" psql << EOF
 set allow_system_table_mods to true;
 
@@ -132,6 +162,7 @@ dump_table t7 after &
 dump_table t9 after &
 wait
 
+# Step 11
 # Verify data integrity.
 diff "$PGBACKREST_TEST_DIR/$TEST_NAME/t1_pre.txt" "$PGBACKREST_TEST_DIR/$TEST_NAME/t1_after.txt"
 diff "$PGBACKREST_TEST_DIR/$TEST_NAME/t3_pre.txt" "$PGBACKREST_TEST_DIR/$TEST_NAME/t3_after.txt"
@@ -140,9 +171,11 @@ diff "$PGBACKREST_TEST_DIR/$TEST_NAME/t6_pre.txt" "$PGBACKREST_TEST_DIR/$TEST_NA
 diff "$PGBACKREST_TEST_DIR/$TEST_NAME/t7_pre.txt" "$PGBACKREST_TEST_DIR/$TEST_NAME/t7_after.txt"
 diff "$PGBACKREST_TEST_DIR/$TEST_NAME/t9_pre.txt" "$PGBACKREST_TEST_DIR/$TEST_NAME/t9_after.txt"
 
+# Step 12
 gprecoverseg -aF
 gpinitstandby -as "$HOSTNAME" -S "$DATADIR/standby" -P $((PGPORT+1))
 
+# Step 13
 # Checking cluster configuration after restore
 psql -c "select * from gp_segment_configuration order by dbid" -o "$PGBACKREST_TEST_DIR/$TEST_NAME/gp_segment_conf_result.out"
 diff "$PGBACKREST_TEST_DIR/$TEST_NAME/gp_segment_conf_expected.out" "$PGBACKREST_TEST_DIR/$TEST_NAME/gp_segment_conf_result.out"

--- a/arenadata/scripts/test_partial_restore_switch_timeline.sh
+++ b/arenadata/scripts/test_partial_restore_switch_timeline.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -exo pipefail
 
-# Test partial restore.
+# Test partial restore with a timeline change between backup and restore point.
 # The test consists of the following steps:
 #  1. Create tables before backup and filling them with data.
 #  2. Create backup
@@ -54,7 +54,7 @@ do
 done
 wait
 
-psql -c "select * from gp_segment_configuration order by dbid" -o "$PGBACKREST_TEST_DIR/$TEST_NAME/gp_segment_conf_expected.out"
+psql -c "select * from gp_segment_configuration order by dbid" -o "$TEST_DIR/$TEST_NAME/gp_segment_conf_expected.out"
 
 # Step 3
 # Create new tables and add data to existing ones.
@@ -128,7 +128,7 @@ rm -rf "${MIRROR1:?}/"* "${MIRROR2:?}/"* "${MIRROR3:?}/"* "$DATADIR/standby/"*
 
 # Step 10
 # Restore the cluster without data to get metadata
-echo "[]" > "$PGBACKREST_TEST_DIR/$TEST_NAME/empty_filter.json"
+echo "[]" > "$TEST_DIR/$TEST_NAME/empty_filter.json"
 for i in -1 0 1 2
 do
     # seg0 has a 3 timeline because it switched between the primary and the mirror twice.
@@ -149,7 +149,7 @@ do
      --type=name \
      --target=backup1 \
      $RESTORE_OPTIONS \
-     --filter="$(realpath "$PGBACKREST_TEST_DIR/$TEST_NAME/empty_filter.json")" \
+     --filter="$(realpath "$TEST_DIR/$TEST_NAME/empty_filter.json")" \
      --target-timeline=$target_timeline \
      restore &
 done
@@ -180,10 +180,10 @@ $(cat /home/gpadmin/pgbackrest/arenadata/scripts/helpers/partial_restore_helper.
 
 # Step 11
 # Dump metadata
-psql -Atc "select * from table_metadata_dump(\$\$'t1','t3','t4','t6','t7','t9'\$\$)" -o "$PGBACKREST_TEST_DIR/$TEST_NAME/filter_seg-1.json"
-psql -Atc "select table_metadata_dump(\$\$'t1','t3','t4','t6','t7','t9'\$\$) from gp_dist_random(\$\$gp_id\$\$) where gp_segment_id = 0;" -o "$PGBACKREST_TEST_DIR/$TEST_NAME/filter_seg0.json"
-psql -Atc "select table_metadata_dump(\$\$'t1','t3','t4','t6','t7','t9'\$\$) from gp_dist_random(\$\$gp_id\$\$) where gp_segment_id = 1;" -o "$PGBACKREST_TEST_DIR/$TEST_NAME/filter_seg1.json"
-psql -Atc "select table_metadata_dump(\$\$'t1','t3','t4','t6','t7','t9'\$\$) from gp_dist_random(\$\$gp_id\$\$) where gp_segment_id = 2;" -o "$PGBACKREST_TEST_DIR/$TEST_NAME/filter_seg2.json"
+psql -Atc "select * from table_metadata_dump(\$\$'t1','t3','t4','t6','t7','t9'\$\$)" -o "$TEST_DIR/$TEST_NAME/filter_seg-1.json"
+psql -Atc "select table_metadata_dump(\$\$'t1','t3','t4','t6','t7','t9'\$\$) from gp_dist_random(\$\$gp_id\$\$) where gp_segment_id = 0;" -o "$TEST_DIR/$TEST_NAME/filter_seg0.json"
+psql -Atc "select table_metadata_dump(\$\$'t1','t3','t4','t6','t7','t9'\$\$) from gp_dist_random(\$\$gp_id\$\$) where gp_segment_id = 1;" -o "$TEST_DIR/$TEST_NAME/filter_seg1.json"
+psql -Atc "select table_metadata_dump(\$\$'t1','t3','t4','t6','t7','t9'\$\$) from gp_dist_random(\$\$gp_id\$\$) where gp_segment_id = 2;" -o "$TEST_DIR/$TEST_NAME/filter_seg2.json"
 
 # Step 12
 gpstop -a
@@ -212,7 +212,7 @@ do
      --type=name \
      --target=backup1 \
      $RESTORE_OPTIONS \
-     --filter="$(realpath "$PGBACKREST_TEST_DIR/$TEST_NAME/filter_seg$i.json")" \
+     --filter="$(realpath "$TEST_DIR/$TEST_NAME/filter_seg$i.json")" \
      --target-timeline=$target_timeline \
      restore &
 done
@@ -245,12 +245,12 @@ wait
 
 # Step 14
 # Verify data integrity.
-diff "$PGBACKREST_TEST_DIR/$TEST_NAME/t1_pre.txt" "$PGBACKREST_TEST_DIR/$TEST_NAME/t1_after.txt"
-diff "$PGBACKREST_TEST_DIR/$TEST_NAME/t3_pre.txt" "$PGBACKREST_TEST_DIR/$TEST_NAME/t3_after.txt"
-diff "$PGBACKREST_TEST_DIR/$TEST_NAME/t4_pre.txt" "$PGBACKREST_TEST_DIR/$TEST_NAME/t4_after.txt"
-diff "$PGBACKREST_TEST_DIR/$TEST_NAME/t6_pre.txt" "$PGBACKREST_TEST_DIR/$TEST_NAME/t6_after.txt"
-diff "$PGBACKREST_TEST_DIR/$TEST_NAME/t7_pre.txt" "$PGBACKREST_TEST_DIR/$TEST_NAME/t7_after.txt"
-diff "$PGBACKREST_TEST_DIR/$TEST_NAME/t9_pre.txt" "$PGBACKREST_TEST_DIR/$TEST_NAME/t9_after.txt"
+diff "$TEST_DIR/$TEST_NAME/t1_pre.txt" "$TEST_DIR/$TEST_NAME/t1_after.txt"
+diff "$TEST_DIR/$TEST_NAME/t3_pre.txt" "$TEST_DIR/$TEST_NAME/t3_after.txt"
+diff "$TEST_DIR/$TEST_NAME/t4_pre.txt" "$TEST_DIR/$TEST_NAME/t4_after.txt"
+diff "$TEST_DIR/$TEST_NAME/t6_pre.txt" "$TEST_DIR/$TEST_NAME/t6_after.txt"
+diff "$TEST_DIR/$TEST_NAME/t7_pre.txt" "$TEST_DIR/$TEST_NAME/t7_after.txt"
+diff "$TEST_DIR/$TEST_NAME/t9_pre.txt" "$TEST_DIR/$TEST_NAME/t9_after.txt"
 
 # Step 15
 gprecoverseg -aF
@@ -259,5 +259,5 @@ gpinitstandby -as "$HOSTNAME" -S "$DATADIR/standby" -P $((PGPORT+1))
 
 # Step 16
 # Checking cluster configuration after restore
-psql -c "select * from gp_segment_configuration order by dbid" -o "$PGBACKREST_TEST_DIR/$TEST_NAME/gp_segment_conf_result.out"
-diff "$PGBACKREST_TEST_DIR/$TEST_NAME/gp_segment_conf_expected.out" "$PGBACKREST_TEST_DIR/$TEST_NAME/gp_segment_conf_result.out"
+psql -c "select * from gp_segment_configuration order by dbid" -o "$TEST_DIR/$TEST_NAME/gp_segment_conf_result.out"
+diff "$TEST_DIR/$TEST_NAME/gp_segment_conf_expected.out" "$TEST_DIR/$TEST_NAME/gp_segment_conf_result.out"

--- a/arenadata/scripts/test_partial_restore_switch_timeline.sh
+++ b/arenadata/scripts/test_partial_restore_switch_timeline.sh
@@ -1,12 +1,33 @@
 #!/usr/bin/env bash
 set -exo pipefail
 
+# Test partial restore.
+# The test consists of the following steps:
+#  1. Create tables before backup and filling them with data.
+#  2. Create backup
+#  3. Create tables after backup and fill them with data. These tables and their data are stored in WAL and must be filtered out
+#  during archive-get.
+#  4. Seg0 went down
+#  5. Seg0 went back
+#  6. Seg2 went down
+#  7. Create a restore point and send the WAL to the archive.
+#  8. Saving the contents of the tables on disk.
+#  9. Stop and delete the cluster.
+#  10. Restore only the system catalog.
+#  11. Create a filter file for each segment. The filter contains both tables created before the backup and tables created after.
+#  12. Stop and delete the cluster.
+#  13. Restoring only a specific set of tables.
+#  14. Check the correctness of the restored data.
+#  15. Restore the mirrors.
+#  16. Check the correctness of cluster restoration.
+
 source /home/gpadmin/pgbackrest/arenadata/scripts/helpers/common.sh
 
 setup_environment $(basename "${0%.sh}") true
 
 # The test scenario starts here
 psql -c "create view random_array as select array_agg((random() * 100)::int) from generate_series(1, 128)a;" &
+# Step 1
 # Create test tables
 psql -c "create table t1 (a int, b int[128]) distributed by(a);" &
 psql -c "create table t2 (a int, b int[128]) distributed by(a);" &
@@ -25,6 +46,7 @@ psql -c "insert into t4 select a, (select * from random_array) from generate_ser
 psql -c "insert into t5 select a, (select * from random_array) from generate_series(1, 100000)a;" &
 wait
 
+# Step 2
 # Create backup
 for i in -1 0 1 2
 do
@@ -34,6 +56,7 @@ wait
 
 psql -c "select * from gp_segment_configuration order by dbid" -o "$PGBACKREST_TEST_DIR/$TEST_NAME/gp_segment_conf_expected.out"
 
+# Step 3
 # Create new tables and add data to existing ones.
 psql -c "create table t3 (a int, b int[128]) distributed by(a);" &
 psql -c "create table t6 (a int, b int[128]) with (appendoptimized=true) distributed by(a);" &
@@ -41,8 +64,10 @@ psql -c "create table t9 (a int, b int[128]) with (appendoptimized=true, orienta
 wait
 psql -c "insert into t3 select a, (select * from random_array) from generate_series(1, 100000)a;"
 
+# Step 4
 # seg0 went down
 kill -9 $(ps aux | grep dbfast1/demoDataDir0 | grep -v grep | awk '{print $2}')
+# Update pgbackrest.conf to archive the WAL from the mirror.
 sudo sed -i 's/dbfast1\/demoDataDir0/dbfast_mirror1\/demoDataDir0/g' /etc/pgbackrest.conf
 sudo sed -i "s/$((PGPORT+2))/$((PGPORT+5))/g" /etc/pgbackrest.conf
 psql -c "select gp_request_fts_probe_scan();"
@@ -51,8 +76,10 @@ psql -c "insert into t6 select a, (select * from random_array) from generate_ser
 psql -c "insert into t9 select a, (select * from random_array) from generate_series(1, 100000)a;" &
 wait
 
+# Step 5
 # seg0 went back
 gprecoverseg -a
+# Wait for sync
 while [[ "$(psql -Atc "select mode from gp_segment_configuration where dbid = 5;")" != "s" ]]; do
     sleep 1
 done
@@ -67,8 +94,10 @@ psql -c "insert into t2 select a, (select * from random_array) from generate_ser
 psql -c "insert into t4 select a, (select * from random_array) from generate_series(1, 100000)a;" &
 wait
 
+# Step 6
 # seg2 went down
 kill -9 $(ps aux | grep dbfast2/demoDataDir1 | grep -v grep | awk '{print $2}')
+# Update pgbackrest.conf to archive the WAL from the mirror and restore to mirror data directory.
 sudo sed -i 's/dbfast2\/demoDataDir1/dbfast_mirror2\/demoDataDir1/g' /etc/pgbackrest.conf
 sudo sed -i "s/$((PGPORT+3))/$((PGPORT+6))/g" /etc/pgbackrest.conf
 psql -c "select gp_request_fts_probe_scan();"
@@ -78,10 +107,12 @@ psql -c "insert into t7 select a, (select * from random_array) from generate_ser
 psql -c "insert into t8 select a, (select * from random_array) from generate_series(1, 100000)a;" &
 wait
 
+# Step 7
 # Create restore point and send wal files to the archive
 psql -c "select gp_create_restore_point('backup1');"
 psql -c "select gp_switch_wal();"
 
+# Step 8
 dump_table t1 pre &
 dump_table t3 pre &
 dump_table t4 pre &
@@ -90,14 +121,19 @@ dump_table t7 pre &
 dump_table t9 pre &
 wait
 
+# Step 9
 gpstop -a
 rm -rf "${MASTER:?}/"* "${PRIMARY1:?}/"* "${PRIMARY2:?}/"* "${PRIMARY3:?}/"*
 rm -rf "${MIRROR1:?}/"* "${MIRROR2:?}/"* "${MIRROR3:?}/"* "$DATADIR/standby/"*
 
+# Step 10
 # Restore the cluster without data to get metadata
-echo "[]" >> "$PGBACKREST_TEST_DIR/$TEST_NAME/empty_filter.json"
+echo "[]" > "$PGBACKREST_TEST_DIR/$TEST_NAME/empty_filter.json"
 for i in -1 0 1 2
 do
+    # seg0 has a 3 timeline because it switched between the primary and the mirror twice.
+    # seg1 has a 2 timeline because it switched between the primary and the mirror once.
+    # The other segments have a 1 timeline since they did not switch between the primary and the mirror.
     target_timeline=1
 
     if [ $i == 0 ]; then
@@ -119,13 +155,13 @@ do
 done
 wait
 
-echo "gp_dbid=6" > /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror2/demoDataDir1/internal.auto.conf
-echo "port=$((PGPORT+6))" >> /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror2/demoDataDir1/postgresql.conf
+# The backup contains a primary, but we are restoring this segment as a mirror. Therefore, we set the correct dbid and port.
+echo "gp_dbid=6" > "$MIRROR2/internal.auto.conf"
+echo "port=$((PGPORT+6))" >> "$MIRROR2/postgresql.conf"
 gpstart -am
 gpinitstandby -ar
 
-PGOPTIONS="-c gp_session_role=utility" psql -c "select * from gp_segment_configuration;"
-
+# Mark mirror segments as unavailable
 PGOPTIONS="-c gp_session_role=utility" psql << EOF
 SET allow_system_table_mods to true;
 
@@ -142,19 +178,25 @@ psql -c "create or replace function table_metadata_dump (to_dump text) returns t
 $(cat /home/gpadmin/pgbackrest/arenadata/scripts/helpers/partial_restore_helper.py)
 \$\$ language $PYTHON_EXTENSION_NAME"
 
+# Step 11
 # Dump metadata
 psql -Atc "select * from table_metadata_dump(\$\$'t1','t3','t4','t6','t7','t9'\$\$)" -o "$PGBACKREST_TEST_DIR/$TEST_NAME/filter_seg-1.json"
 psql -Atc "select table_metadata_dump(\$\$'t1','t3','t4','t6','t7','t9'\$\$) from gp_dist_random(\$\$gp_id\$\$) where gp_segment_id = 0;" -o "$PGBACKREST_TEST_DIR/$TEST_NAME/filter_seg0.json"
 psql -Atc "select table_metadata_dump(\$\$'t1','t3','t4','t6','t7','t9'\$\$) from gp_dist_random(\$\$gp_id\$\$) where gp_segment_id = 1;" -o "$PGBACKREST_TEST_DIR/$TEST_NAME/filter_seg1.json"
 psql -Atc "select table_metadata_dump(\$\$'t1','t3','t4','t6','t7','t9'\$\$) from gp_dist_random(\$\$gp_id\$\$) where gp_segment_id = 2;" -o "$PGBACKREST_TEST_DIR/$TEST_NAME/filter_seg2.json"
 
+# Step 12
 gpstop -a
 rm -rf "${MASTER:?}/"* "${PRIMARY1:?}/"* "${PRIMARY2:?}/"* "${PRIMARY3:?}/"*
 rm -rf "${MIRROR1:?}/"* "${MIRROR2:?}/"* "${MIRROR3:?}/"* "$DATADIR/standby/"*
 
-# Restore only tables t1, t3, t3 and t6
+# Step 13
+# Restore only tables t1, t3, t4, t6, t7 and t9
 for i in -1 0 1 2
 do
+    # seg0 has a 3 timeline because it switched between the primary and the mirror twice.
+    # seg1 has a 2 timeline because it switched between the primary and the mirror once.
+    # The other segments have a 1 timeline since they did not switch between the primary and the mirror.
     target_timeline=1
 
     if [ $i == 0 ]; then
@@ -176,11 +218,13 @@ do
 done
 wait
 
-echo "gp_dbid=6" > /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror2/demoDataDir1/internal.auto.conf
-echo "port=$((PGPORT+6))" >> /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror2/demoDataDir1/postgresql.conf
+# The backup contains a primary, but we are restoring this segment as a mirror. Therefore, we set the correct dbid and port.
+echo "gp_dbid=6" > "$MIRROR2/internal.auto.conf"
+echo "port=$((PGPORT+6))" >> "$MIRROR2/postgresql.conf"
 gpstart -am
 gpinitstandby -ar
 
+# Mark mirror segments as unavailable
 PGOPTIONS="-c gp_session_role=utility" psql << EOF
 SET allow_system_table_mods to true;
 
@@ -199,6 +243,7 @@ dump_table t7 after &
 dump_table t9 after &
 wait
 
+# Step 14
 # Verify data integrity.
 diff "$PGBACKREST_TEST_DIR/$TEST_NAME/t1_pre.txt" "$PGBACKREST_TEST_DIR/$TEST_NAME/t1_after.txt"
 diff "$PGBACKREST_TEST_DIR/$TEST_NAME/t3_pre.txt" "$PGBACKREST_TEST_DIR/$TEST_NAME/t3_after.txt"
@@ -207,10 +252,12 @@ diff "$PGBACKREST_TEST_DIR/$TEST_NAME/t6_pre.txt" "$PGBACKREST_TEST_DIR/$TEST_NA
 diff "$PGBACKREST_TEST_DIR/$TEST_NAME/t7_pre.txt" "$PGBACKREST_TEST_DIR/$TEST_NAME/t7_after.txt"
 diff "$PGBACKREST_TEST_DIR/$TEST_NAME/t9_pre.txt" "$PGBACKREST_TEST_DIR/$TEST_NAME/t9_after.txt"
 
+# Step 15
 gprecoverseg -aF
 gprecoverseg -ar
 gpinitstandby -as "$HOSTNAME" -S "$DATADIR/standby" -P $((PGPORT+1))
 
+# Step 16
 # Checking cluster configuration after restore
 psql -c "select * from gp_segment_configuration order by dbid" -o "$PGBACKREST_TEST_DIR/$TEST_NAME/gp_segment_conf_result.out"
 diff "$PGBACKREST_TEST_DIR/$TEST_NAME/gp_segment_conf_expected.out" "$PGBACKREST_TEST_DIR/$TEST_NAME/gp_segment_conf_result.out"

--- a/arenadata/scripts/test_partial_restore_switch_timeline.sh
+++ b/arenadata/scripts/test_partial_restore_switch_timeline.sh
@@ -7,7 +7,7 @@ setup_environment $(basename "${0%.sh}") true
 
 # The test scenario starts here
 psql -c "create view random_array as select array_agg((random() * 100)::int) from generate_series(1, 128)a;" &
-# Сreate test tables
+# Create test tables
 psql -c "create table t1 (a int, b int[128]) distributed by(a);" &
 psql -c "create table t2 (a int, b int[128]) distributed by(a);" &
 
@@ -23,29 +23,56 @@ psql -c "insert into t2 select a, (select * from random_array) from generate_ser
 
 psql -c "insert into t4 select a, (select * from random_array) from generate_series(1, 100000)a;" &
 psql -c "insert into t5 select a, (select * from random_array) from generate_series(1, 100000)a;" &
-
 wait
 
-# Сreate backup
+# Create backup
 for i in -1 0 1 2
 do
     PGOPTIONS="-c gp_session_role=utility" pgbackrest --stanza=seg$i --type=full backup &
 done
 wait
 
+psql -c "select * from gp_segment_configuration order by dbid" -o "$PGBACKREST_TEST_DIR/$TEST_NAME/gp_segment_conf_expected.out"
+
 # Create new tables and add data to existing ones.
 psql -c "create table t3 (a int, b int[128]) distributed by(a);" &
-# Add several checkpoints inside the transaction to test the pending delete records.
-psql -c "begin; create table t6 (a int, b int[128]) with (appendoptimized=true) distributed by(a); checkpoint; commit;" &
-psql -c "begin; create table t9 (a int, b int[128]) with (appendoptimized=true, orientation=column) distributed by(a); checkpoint; commit;" &
+psql -c "create table t6 (a int, b int[128]) with (appendoptimized=true) distributed by(a);" &
+psql -c "create table t9 (a int, b int[128]) with (appendoptimized=true, orientation=column) distributed by(a);" &
 wait
-psql -c "insert into t3 select a, (select * from random_array) from generate_series(1, 100000)a;" &
+psql -c "insert into t3 select a, (select * from random_array) from generate_series(1, 100000)a;"
+
+# seg0 went down
+kill -9 $(ps aux | grep dbfast1/demoDataDir0 | grep -v grep | awk '{print $2}')
+sudo sed -i 's/dbfast1\/demoDataDir0/dbfast_mirror1\/demoDataDir0/g' /etc/pgbackrest.conf
+sudo sed -i "s/$((PGPORT+2))/$((PGPORT+5))/g" /etc/pgbackrest.conf
+psql -c "select gp_request_fts_probe_scan();"
+
 psql -c "insert into t6 select a, (select * from random_array) from generate_series(1, 100000)a;" &
 psql -c "insert into t9 select a, (select * from random_array) from generate_series(1, 100000)a;" &
+wait
+
+# seg0 went back
+gprecoverseg -a
+while [[ "$(psql -Atc "select mode from gp_segment_configuration where dbid = 5;")" != "s" ]]; do
+    sleep 1
+done
+gprecoverseg -ar
+
+sudo sed -i 's/dbfast_mirror1\/demoDataDir0/dbfast1\/demoDataDir0/g' /etc/pgbackrest.conf
+sudo sed -i "s/$((PGPORT+5))/$((PGPORT+2))/g" /etc/pgbackrest.conf
+psql -c "select gp_request_fts_probe_scan();"
 
 psql -c "insert into t1 select a, (select * from random_array) from generate_series(1, 100000)a;" &
 psql -c "insert into t2 select a, (select * from random_array) from generate_series(1, 100000)a;" &
 psql -c "insert into t4 select a, (select * from random_array) from generate_series(1, 100000)a;" &
+wait
+
+# seg2 went down
+kill -9 $(ps aux | grep dbfast2/demoDataDir1 | grep -v grep | awk '{print $2}')
+sudo sed -i 's/dbfast2\/demoDataDir1/dbfast_mirror2\/demoDataDir1/g' /etc/pgbackrest.conf
+sudo sed -i "s/$((PGPORT+3))/$((PGPORT+6))/g" /etc/pgbackrest.conf
+psql -c "select gp_request_fts_probe_scan();"
+
 psql -c "insert into t5 select a, (select * from random_array) from generate_series(1, 100000)a;" &
 psql -c "insert into t7 select a, (select * from random_array) from generate_series(1, 100000)a;" &
 psql -c "insert into t8 select a, (select * from random_array) from generate_series(1, 100000)a;" &
@@ -63,8 +90,6 @@ dump_table t7 pre &
 dump_table t9 pre &
 wait
 
-psql -c "select * from gp_segment_configuration order by dbid" -o "$PGBACKREST_TEST_DIR/$TEST_NAME/gp_segment_conf_expected.out"
-
 gpstop -a
 rm -rf "${MASTER:?}/"* "${PRIMARY1:?}/"* "${PRIMARY2:?}/"* "${PRIMARY3:?}/"*
 rm -rf "${MIRROR1:?}/"* "${MIRROR2:?}/"* "${MIRROR3:?}/"* "$DATADIR/standby/"*
@@ -73,19 +98,40 @@ rm -rf "${MIRROR1:?}/"* "${MIRROR2:?}/"* "${MIRROR3:?}/"* "$DATADIR/standby/"*
 echo "[]" >> "$PGBACKREST_TEST_DIR/$TEST_NAME/empty_filter.json"
 for i in -1 0 1 2
 do
-    pgbackrest --stanza=seg$i --type=name --target=backup1 $RESTORE_OPTIONS --filter="$(realpath "$PGBACKREST_TEST_DIR/$TEST_NAME/empty_filter.json")" restore &
+    target_timeline=1
+
+    if [ $i == 0 ]; then
+      target_timeline=3
+    fi
+
+    if [ $i == 1 ]; then
+      target_timeline=2
+    fi
+
+    pgbackrest \
+     --stanza=seg$i \
+     --type=name \
+     --target=backup1 \
+     $RESTORE_OPTIONS \
+     --filter="$(realpath "$PGBACKREST_TEST_DIR/$TEST_NAME/empty_filter.json")" \
+     --target-timeline=$target_timeline \
+     restore &
 done
 wait
 
+echo "gp_dbid=6" > /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror2/demoDataDir1/internal.auto.conf
+echo "port=$((PGPORT+6))" >> /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror2/demoDataDir1/postgresql.conf
 gpstart -am
 gpinitstandby -ar
 
-PGOPTIONS="-c gp_session_role=utility" psql << EOF
-set allow_system_table_mods to true;
+PGOPTIONS="-c gp_session_role=utility" psql -c "select * from gp_segment_configuration;"
 
-update gp_segment_configuration
-set status = case when role='m' then 'd' else status end, mode = 'n'
-where content >= 0;
+PGOPTIONS="-c gp_session_role=utility" psql << EOF
+SET allow_system_table_mods to true;
+
+UPDATE gp_segment_configuration
+SET status = CASE WHEN role='m' THEN 'd' ELSE status END, mode = 'n'
+WHERE content >= 0;
 EOF
 gpstop -ra
 # Prevent sending the WAL to the archive while receiving the metadata of the tables
@@ -104,22 +150,43 @@ psql -Atc "select table_metadata_dump(\$\$'t1','t3','t4','t6','t7','t9'\$\$) fro
 
 gpstop -a
 rm -rf "${MASTER:?}/"* "${PRIMARY1:?}/"* "${PRIMARY2:?}/"* "${PRIMARY3:?}/"*
+rm -rf "${MIRROR1:?}/"* "${MIRROR2:?}/"* "${MIRROR3:?}/"* "$DATADIR/standby/"*
 
 # Restore only tables t1, t3, t3 and t6
 for i in -1 0 1 2
 do
-    pgbackrest --stanza=seg$i --type=name --target=backup1 $RESTORE_OPTIONS --filter="$(realpath "$PGBACKREST_TEST_DIR/$TEST_NAME/filter_seg$i.json")" restore &
+    target_timeline=1
+
+    if [ $i == 0 ]; then
+      target_timeline=3
+    fi
+
+    if [ $i == 1 ]; then
+      target_timeline=2
+    fi
+
+    pgbackrest \
+     --stanza=seg$i \
+     --type=name \
+     --target=backup1 \
+     $RESTORE_OPTIONS \
+     --filter="$(realpath "$PGBACKREST_TEST_DIR/$TEST_NAME/filter_seg$i.json")" \
+     --target-timeline=$target_timeline \
+     restore &
 done
 wait
 
+echo "gp_dbid=6" > /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror2/demoDataDir1/internal.auto.conf
+echo "port=$((PGPORT+6))" >> /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/dbfast_mirror2/demoDataDir1/postgresql.conf
 gpstart -am
 gpinitstandby -ar
-PGOPTIONS="-c gp_session_role=utility" psql << EOF
-set allow_system_table_mods to true;
 
-update gp_segment_configuration
-set status = case when role='m' then 'd' else status end, mode = 'n'
-where content >= 0;
+PGOPTIONS="-c gp_session_role=utility" psql << EOF
+SET allow_system_table_mods to true;
+
+UPDATE gp_segment_configuration
+SET status = CASE WHEN role='m' THEN 'd' ELSE status END, mode = 'n'
+WHERE content >= 0;
 EOF
 gpstop -ra
 
@@ -141,6 +208,7 @@ diff "$PGBACKREST_TEST_DIR/$TEST_NAME/t7_pre.txt" "$PGBACKREST_TEST_DIR/$TEST_NA
 diff "$PGBACKREST_TEST_DIR/$TEST_NAME/t9_pre.txt" "$PGBACKREST_TEST_DIR/$TEST_NAME/t9_after.txt"
 
 gprecoverseg -aF
+gprecoverseg -ar
 gpinitstandby -as "$HOSTNAME" -S "$DATADIR/standby" -P $((PGPORT+1))
 
 # Checking cluster configuration after restore

--- a/arenadata/scripts/test_pitr_gpdb.sh
+++ b/arenadata/scripts/test_pitr_gpdb.sh
@@ -1,72 +1,9 @@
 #!/usr/bin/env bash
 set -exo pipefail
 
-PGBACKREST_TEST_DIR=/home/gpadmin/test_pgbackrest
+source /home/gpadmin/pgbackrest/arenadata/scripts/helpers/common.sh
 
-# Starting up demo cluster
-source "/usr/local/greenplum-db-devel/greenplum_path.sh"
-pushd gpdb_src/gpAux/gpdemo
-make create-demo-cluster WITH_MIRRORS=true
-source gpdemo-env.sh
-popd
-
-# Creating backup and log directories for pgbackrest
-TEST_NAME=$(basename "${0%.sh}")
-mkdir -p "$PGBACKREST_TEST_DIR/logs/$TEST_NAME"
-mkdir -p "$PGBACKREST_TEST_DIR/$TEST_NAME"
-DATADIR="${MASTER_DATA_DIRECTORY%*/*/*}"
-MASTER=${DATADIR}/qddir/demoDataDir-1
-PRIMARY1=${DATADIR}/dbfast1/demoDataDir0
-PRIMARY2=${DATADIR}/dbfast2/demoDataDir1
-PRIMARY3=${DATADIR}/dbfast3/demoDataDir2
-MIRROR1=${DATADIR}/dbfast_mirror1/demoDataDir0
-MIRROR2=${DATADIR}/dbfast_mirror2/demoDataDir1
-MIRROR3=${DATADIR}/dbfast_mirror3/demoDataDir2
-
-# Filling the pgbackrest.conf configuration file
-cat <<EOF > /etc/pgbackrest.conf
-[seg-1]
-pg1-path=$MASTER
-pg1-port=$PGPORT
-
-[seg0]
-pg1-path=$PRIMARY1
-pg1-port=$((PGPORT+2))
-
-[seg1]
-pg1-path=$PRIMARY2
-pg1-port=$((PGPORT+3))
-
-[seg2]
-pg1-path=$PRIMARY3
-pg1-port=$((PGPORT+4))
-
-[global]
-repo1-path=$PGBACKREST_TEST_DIR/$TEST_NAME
-log-path=$PGBACKREST_TEST_DIR/logs/$TEST_NAME
-start-fast=y
-fork=GPDB
-EOF
-
-# Initializing pgbackrest for GPDB
-for i in -1 0 1 2
-do 
-    PGOPTIONS="-c gp_session_role=utility" pgbackrest --stanza=seg$i stanza-create
-done
-
-# Configuring WAL archiving command
-gpconfig -c archive_mode -v on
-
-gpconfig -c archive_command -v "'PGOPTIONS=\"-c gp_session_role=utility\" \
-pgbackrest --stanza=seg%c archive-push %p'" --skipvalidation
-
-gpstop -ar
-
-# pgbackrest health check
-for i in -1 0 1 2
-do 
-    PGOPTIONS="-c gp_session_role=utility" pgbackrest --stanza=seg$i check
-done
+setup_environment $(basename "${0%.sh}") true
 
 # The test scenario starts here
 # Creating initial dataset
@@ -80,8 +17,9 @@ psql -c "SELECT * FROM gp_segment_configuration ORDER BY dbid" -o "$PGBACKREST_T
 # Creating full backup on master and seg0
 for i in -1 0
 do 
-    PGOPTIONS="-c gp_session_role=utility" pgbackrest --stanza=seg$i --type=full backup
+    PGOPTIONS="-c gp_session_role=utility" pgbackrest --stanza=seg$i --type=full backup &
 done
+wait
 
 # Checking the presence of first backup
 function check_backup(){
@@ -113,8 +51,9 @@ psql -c "SELECT * FROM t1 ORDER BY id;" \
 # Creating full backup on seg1 and seg2
 for i in 1 2
 do 
-    PGOPTIONS="-c gp_session_role=utility" pgbackrest --stanza=seg$i --type=full backup
+    PGOPTIONS="-c gp_session_role=utility" pgbackrest --stanza=seg$i --type=full backup &
 done
+wait
 
 # Checking the presence of second backup
 for i in 1 2
@@ -147,8 +86,9 @@ rm -rf "${MIRROR1:?}/"* "${MIRROR2:?}/"* "${MIRROR3:?}/"* "$DATADIR/standby/"*
 # Restoring cluster
 for i in -1 0 1 2
 do 
-    pgbackrest --stanza=seg$i --type=name --target=test_pitr $RESTORE_OPTIONS restore
+    pgbackrest --stanza=seg$i --type=name --target=test_pitr $RESTORE_OPTIONS restore &
 done
+wait
 
 # Configuring mirrors after primary restore
 gpstart -am

--- a/arenadata/scripts/test_pitr_gpdb.sh
+++ b/arenadata/scripts/test_pitr_gpdb.sh
@@ -12,7 +12,7 @@ createdb
 psql -c "CREATE TABLE t1 AS SELECT id, 'text'||id AS text FROM generate_series(1,30) id DISTRIBUTED BY (id);"
 
 # Saving cluster configuration status
-psql -c "SELECT * FROM gp_segment_configuration ORDER BY dbid" -o "$PGBACKREST_TEST_DIR/$TEST_NAME/gp_segment_conf_expected.out"
+psql -c "SELECT * FROM gp_segment_configuration ORDER BY dbid" -o "$TEST_DIR/$TEST_NAME/gp_segment_conf_expected.out"
 
 # Creating full backup on master and seg0
 for i in -1 0
@@ -23,7 +23,7 @@ wait
 
 # Checking the presence of first backup
 function check_backup(){
-    segment_backup_dir=$PGBACKREST_TEST_DIR/$TEST_NAME/backup/seg$1
+    segment_backup_dir=$TEST_DIR/$TEST_NAME/backup/seg$1
     current_date=$(date +%Y%m%d)
         
     if [[ -z $(find "$segment_backup_dir" -maxdepth 1 -type d -name "${current_date}-??????F" -not -empty ) ]];
@@ -40,13 +40,13 @@ done
 psql -c "CREATE TABLE t2 AS SELECT id, 'text'||id AS text FROM generate_series(1,30) id DISTRIBUTED BY (id);"
 
 psql -c "SELECT * FROM t2 ORDER BY id;" \
--o "$PGBACKREST_TEST_DIR/$TEST_NAME/t2_rows_original.out"
+-o "$TEST_DIR/$TEST_NAME/t2_rows_original.out"
 
 # Filling the first table with more data at seg0 after the first backup
 psql -c "INSERT INTO t1 SELECT 3, 'text'||i FROM generate_series(1,10) i;"
 
 psql -c "SELECT * FROM t1 ORDER BY id;" \
--o "$PGBACKREST_TEST_DIR/$TEST_NAME/t1_rows_original.out"
+-o "$TEST_DIR/$TEST_NAME/t1_rows_original.out"
 
 # Creating full backup on seg1 and seg2
 for i in 1 2
@@ -106,17 +106,17 @@ gprecoverseg -aF
 gpinitstandby -as "$HOSTNAME" -S "$DATADIR/standby" -P $((PGPORT+1))
 
 # Checking cluster configuration after restore
-psql -c "SELECT * FROM gp_segment_configuration ORDER BY dbid" -o "$PGBACKREST_TEST_DIR/$TEST_NAME/gp_segment_conf_result.out"
+psql -c "SELECT * FROM gp_segment_configuration ORDER BY dbid" -o "$TEST_DIR/$TEST_NAME/gp_segment_conf_result.out"
 
-diff "$PGBACKREST_TEST_DIR/$TEST_NAME/gp_segment_conf_expected.out" "$PGBACKREST_TEST_DIR/$TEST_NAME/gp_segment_conf_result.out"
+diff "$TEST_DIR/$TEST_NAME/gp_segment_conf_expected.out" "$TEST_DIR/$TEST_NAME/gp_segment_conf_result.out"
 
 # Checking data integrity
 psql -c "SELECT * FROM t1 ORDER BY id;" \
--o "$PGBACKREST_TEST_DIR/$TEST_NAME/t1_rows_restored.out"
+-o "$TEST_DIR/$TEST_NAME/t1_rows_restored.out"
 
 psql -c "SELECT * FROM t2 ORDER BY id;" \
--o "$PGBACKREST_TEST_DIR/$TEST_NAME/t2_rows_restored.out"
+-o "$TEST_DIR/$TEST_NAME/t2_rows_restored.out"
 
-diff "$PGBACKREST_TEST_DIR/$TEST_NAME/t1_rows_original.out" "$PGBACKREST_TEST_DIR/$TEST_NAME/t1_rows_restored.out"
+diff "$TEST_DIR/$TEST_NAME/t1_rows_original.out" "$TEST_DIR/$TEST_NAME/t1_rows_restored.out"
 
-diff "$PGBACKREST_TEST_DIR/$TEST_NAME/t2_rows_original.out" "$PGBACKREST_TEST_DIR/$TEST_NAME/t2_rows_restored.out"
+diff "$TEST_DIR/$TEST_NAME/t2_rows_original.out" "$TEST_DIR/$TEST_NAME/t2_rows_restored.out"

--- a/test/define.yaml
+++ b/test/define.yaml
@@ -462,7 +462,7 @@ unit:
           - storage/remote/write
       # ----------------------------------------------------------------------------------------------------------------------------
       - name: walFilterGPDB6
-        total: 7
+        total: 8
         harness: wal
         harness: info
         harness: postgres

--- a/test/src/common/harnessWal.h
+++ b/test/src/common/harnessWal.h
@@ -25,11 +25,12 @@ typedef struct InsertXRecordParam
 {
     VAR_PARAM_HEADER;
     uint16 magic;
-    uint32 beginOffset;
+    uint32 remLen;
     uint64 segno;
     uint32 segSize;
     PgPageSize walPageSize;
     uint32 incompletePosition;
+    uint32 timeline;
 } InsertXRecordParam;
 
 typedef struct CreateXRecordParam

--- a/test/src/module/common/walFilterGPDB6Test.c
+++ b/test/src/module/common/walFilterGPDB6Test.c
@@ -186,6 +186,40 @@ calcBodySize(uint32 pageCount, uint32 leftOnLastPage, XLogRecPtr recPtr, uint32 
     return totalSize;
 }
 
+static void
+fillWalWithRecords(Buffer *wal, uint32 targetOffset, uint32 segSize)
+{
+    if (targetOffset == SizeOfXLogLongPHD)
+    {
+        return;
+    }
+
+    // We stop when we get close to the target offset by the page size.
+    while (targetOffset - bufUsed(wal) > DEFAULT_GDPB_XLOG_PAGE_SIZE)
+    {
+        XLogRecordBase *record = createXRecord(
+            RM_XLOG_ID,
+            XLOG_NOOP,
+            // We make the size of the record body random but not larger than the page size and not zero.
+            .body_size = ((uint32) rand() % DEFAULT_GDPB_XLOG_PAGE_SIZE) + 1);
+        if (bufUsed(wal) + record->xl_tot_len > targetOffset)
+        {
+            break;
+        }
+        insertXRecord(wal,record, NO_FLAGS, .segno = 1, .segSize = segSize);
+    }
+
+    uint32 bodySize = (uint32) (targetOffset - bufUsed(wal) - SizeOfXLogRecordGPDB6);
+    // If we are at the beginning of the page, we need to take into account its header.
+    if (bufUsed(wal) % DEFAULT_GDPB_XLOG_PAGE_SIZE == 0)
+    {
+        bodySize -= (uint32) SizeOfXLogShortPHD;
+    }
+
+    XLogRecordBase *record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = bodySize);
+    insertXRecord(wal, record, NO_FLAGS, .segno = 1, .segSize = segSize);
+}
+
 /***********************************************************************************************************************************
 Test Run
 ***********************************************************************************************************************************/
@@ -198,20 +232,19 @@ testRun(void)
     Buffer *result;
     XLogRecordBase *record;
     const Storage *storageTest = storagePosixNewP(TEST_PATH_STR, .write = true);
+    StringList *argBaseList = strLstNew();
+    hrnCfgArgRawZ(argBaseList, cfgOptFork, CFGOPTVAL_FORK_GPDB_Z);
+    hrnCfgArgRawZ(argBaseList, cfgOptPgPath, TEST_PATH "/pg");
+    hrnCfgArgRawZ(argBaseList, cfgOptRepoPath, TEST_PATH "/repo");
+    hrnCfgArgRawZ(argBaseList, cfgOptStanza, "test1");
+    hrnCfgArgRawZ(argBaseList, cfgOptFilter, TEST_PATH "/recovery_filter.json");
+    HRN_CFG_LOAD(cfgCmdArchiveGet, argBaseList);
 
     if (testBegin("read begin of the record from prev file"))
     {
         Buffer *wal2;
-        StringList *argBaseList = strLstNew();
-        hrnCfgArgRawZ(argBaseList, cfgOptFork, CFGOPTVAL_FORK_GPDB_Z);
-        hrnCfgArgRawZ(argBaseList, cfgOptPgPath, TEST_PATH "/pg");
-        hrnCfgArgRawZ(argBaseList, cfgOptRepoPath, TEST_PATH "/repo");
-        hrnCfgArgRawZ(argBaseList, cfgOptStanza, "test1");
 
         HRN_STORAGE_PUT_Z(storageTest, "recovery_filter.json", "[]");
-        hrnCfgArgRawZ(argBaseList, cfgOptFilter, TEST_PATH "/recovery_filter.json");
-
-        HRN_CFG_LOAD(cfgCmdArchiveGet, argBaseList);
 
         HRN_PG_CONTROL_OVERRIDE_VERSION_PUT(
             storagePgWrite(), PG_VERSION_94, 9420600, .systemId = HRN_PG_SYSTEMID_94, .catalogVersion = 301908232,
@@ -236,9 +269,7 @@ testRun(void)
 
         HRN_STORAGE_PATH_CREATE(storageRepoIdxWrite(0), STORAGE_REPO_ARCHIVE "/9.4-1");
         ArchiveGetFile archiveInfo = {
-            .file = STRDEF(
-                STORAGE_REPO_ARCHIVE
-                "/9.4-1/0000000100000000/000000010000000000000002-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd.gz"),
+            .file = STRDEF(".gz"), // this field is used to determine compression algorithm
             .repoIdx = 0,
             .archiveId = STRDEF("9.4-1"),
             .cipherType = cipherTypeNone,
@@ -267,7 +298,7 @@ testRun(void)
 
         wal2 = bufNew(1024 * 1024);
         record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = 100);
-        hrnGpdbWalInsertXRecordP(wal2, record, NO_FLAGS, .segno = 2, .beginOffset = 132 - 8);
+        hrnGpdbWalInsertXRecordP(wal2, record, NO_FLAGS, .segno = 2, .remLen = 132 - 8);
         insertWalSwitchXRecord(wal2);
 
         fillLastPage(wal2, DEFAULT_GDPB_XLOG_PAGE_SIZE);
@@ -277,8 +308,78 @@ testRun(void)
         HRN_STORAGE_REMOVE(
             storageRepoWrite(),
             STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000001-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd.gz");
-        archiveInfo.file = STRDEF(
-            STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000002-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd");
+        archiveInfo.file = STRDEF("");
+        MEM_CONTEXT_TEMP_END();
+
+        TEST_TITLE("an unfinished recprd at the beginning of the file is a wal switch");
+        MEM_CONTEXT_TEMP_BEGIN();
+        filter = walFilterNew(pgControl, &archiveInfo);
+        {
+            Buffer *wal1 = bufNew(DEFAULT_GDPB_XLOG_PAGE_SIZE);
+
+            record = createXRecord(
+                RM_XLOG_ID, XLOG_NOOP, .body_size = DEFAULT_GDPB_XLOG_PAGE_SIZE - SizeOfXLogLongPHD - SizeOfXLogRecordGPDB6 - 16);
+            insertXRecord(wal1, record, NO_FLAGS);
+
+            record = createXRecord(RM_XLOG_ID, XLOG_SWITCH);
+            insertXRecord(wal1, record, INCOMPLETE_RECORD);
+            fillLastPage(wal1, DEFAULT_GDPB_XLOG_PAGE_SIZE);
+
+            HRN_STORAGE_PUT(
+                storageRepoWrite(),
+                STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000001-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
+                wal1);
+        }
+
+        wal2 = bufNew(DEFAULT_GDPB_XLOG_PAGE_SIZE);
+        record = createXRecord(RM_XLOG_ID, XLOG_SWITCH);
+        insertXRecord(wal2, record, NO_FLAGS, .segno = 2, .remLen = SizeOfXLogRecordGPDB6 - 16);
+
+        fillLastPage(wal2, DEFAULT_GDPB_XLOG_PAGE_SIZE);
+        result = testFilter(filter, wal2, bufSize(wal2), bufSize(wal2));
+        TEST_RESULT_BOOL(bufEq(wal2, result), true, "WAL not the same");
+
+        HRN_STORAGE_REMOVE(
+            storageRepoWrite(),
+            STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000001-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd");
+        MEM_CONTEXT_TEMP_END();
+
+        TEST_TITLE("prev file is in the different timeline");
+        MEM_CONTEXT_TEMP_BEGIN();
+        filter = walFilterNew(pgControl, &archiveInfo);
+        {
+            Buffer *wal1 = bufNew(DEFAULT_GDPB_XLOG_PAGE_SIZE);
+
+            record = createXRecord(
+                RM_XLOG_ID, XLOG_NOOP, .body_size = DEFAULT_GDPB_XLOG_PAGE_SIZE - SizeOfXLogLongPHD - SizeOfXLogRecordGPDB6 - 8);
+            insertXRecord(wal1, record, NO_FLAGS);
+
+            record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = 100);
+            insertXRecord(wal1, record, INCOMPLETE_RECORD);
+            fillLastPage(wal1, DEFAULT_GDPB_XLOG_PAGE_SIZE);
+
+            HRN_STORAGE_PUT(
+                storageRepoWrite(),
+                STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000001-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
+                wal1);
+        }
+
+        wal2 = bufNew(1024 * 1024);
+        record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = 100);
+        insertXRecord(wal2, record, NO_FLAGS, .segno = 2, .remLen = 132 - 8);
+        // Somewhere here, a timeline switch has happened.
+        record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = DEFAULT_GDPB_XLOG_PAGE_SIZE * 2);
+        insertXRecord(wal2, record, NO_FLAGS, .segno = 2, .timeline = 2);
+        insertWalSwitchXRecord(wal2);
+
+        fillLastPage(wal2, DEFAULT_GDPB_XLOG_PAGE_SIZE);
+        result = testFilter(filter, wal2, bufSize(wal2), bufSize(wal2));
+        TEST_RESULT_BOOL(bufEq(wal2, result), true, "WAL not the same");
+
+        HRN_STORAGE_REMOVE(
+            storageRepoWrite(),
+            STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000001-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd");
+        archiveInfo.file = STRDEF("");
         MEM_CONTEXT_TEMP_END();
 
         TEST_TITLE("prev file is partial");
@@ -296,7 +397,7 @@ testRun(void)
 
         wal2 = bufNew(1024 * 1024);
         record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = 100);
-        hrnGpdbWalInsertXRecordP(wal2, record, NO_FLAGS, .segno = 2, .beginOffset = 132 - 8);
+        hrnGpdbWalInsertXRecordP(wal2, record, NO_FLAGS, .segno = 2, .remLen = 132 - 8);
         insertWalSwitchXRecord(wal2);
 
         fillLastPage(wal2, DEFAULT_GDPB_XLOG_PAGE_SIZE);
@@ -307,14 +408,10 @@ testRun(void)
         HRN_STORAGE_REMOVE(
             storageRepoWrite(),
             STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000001.partial-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd");
-        archiveInfo.file = STRDEF(
-            STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000002-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd");
         MEM_CONTEXT_TEMP_END();
 
         TEST_TITLE("prev file is in the another directory");
         MEM_CONTEXT_TEMP_BEGIN();
-        archiveInfo.file = STRDEF(
-            STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000001/000000010000000100000000-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd");
         filter = walFilterNew(pgControl, &archiveInfo);
         {
             Buffer *wal1 = bufNew(DEFAULT_GDPB_XLOG_PAGE_SIZE);
@@ -350,7 +447,7 @@ testRun(void)
         // 40  124 32
         // LPH RM  RH
         record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = 100);
-        hrnGpdbWalInsertXRecordP(wal2, record, NO_FLAGS, .segno = 64, .beginOffset = 132 - 8);
+        hrnGpdbWalInsertXRecordP(wal2, record, NO_FLAGS, .segno = 64, .remLen = 132 - 8);
         insertWalSwitchXRecord(wal2);
 
         fillLastPage(wal2, DEFAULT_GDPB_XLOG_PAGE_SIZE);
@@ -360,8 +457,6 @@ testRun(void)
         HRN_STORAGE_REMOVE(
             storageRepoWrite(),
             STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/00000001000000000000003F-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd");
-        archiveInfo.file = STRDEF(
-            STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000002-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd");
         MEM_CONTEXT_TEMP_END();
 
         TEST_TITLE("incomplete record in the beginning of prev file");
@@ -370,7 +465,7 @@ testRun(void)
         {
             Buffer *wal1 = bufNew(DEFAULT_GDPB_XLOG_PAGE_SIZE);
             record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = 100);
-            hrnGpdbWalInsertXRecordP(wal1, record, NO_FLAGS, .beginOffset = 132 - 8);
+            hrnGpdbWalInsertXRecordP(wal1, record, NO_FLAGS, .remLen = 132 - 8);
             // 124 - size of first record on current page
             // 8 - the number of bytes that we want to leave free at the end of the page.
             // 4 - making the record size aligned to 8 bytes
@@ -391,7 +486,7 @@ testRun(void)
         }
         wal2 = bufNew(1024 * 1024);
         record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = 100);
-        hrnGpdbWalInsertXRecordP(wal2, record, NO_FLAGS, .segno = 2, .beginOffset = 132 - 8);
+        hrnGpdbWalInsertXRecordP(wal2, record, NO_FLAGS, .segno = 2, .remLen = 132 - 8);
         insertWalSwitchXRecord(wal2);
 
         fillLastPage(wal2, DEFAULT_GDPB_XLOG_PAGE_SIZE);
@@ -417,7 +512,7 @@ testRun(void)
             // LPH  RM   |SPH  RM  |SPH RM RH   B   |
             Buffer *wal1 = bufNew(DEFAULT_GDPB_XLOG_PAGE_SIZE * 3);
             record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = DEFAULT_GDPB_XLOG_PAGE_SIZE * 3);
-            insertXRecord(wal1, record, NO_FLAGS, .beginOffset = DEFAULT_GDPB_XLOG_PAGE_SIZE * 2);
+            insertXRecord(wal1, record, NO_FLAGS, .remLen = DEFAULT_GDPB_XLOG_PAGE_SIZE * 2);
 
             record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = DEFAULT_GDPB_XLOG_PAGE_SIZE * 2);
             insertXRecord(wal1, record, INCOMPLETE_RECORD);
@@ -443,7 +538,7 @@ testRun(void)
             record,
             NO_FLAGS,
             .segno = 2,
-            .beginOffset = 32728 + 160);
+            .remLen = 32728 + 160);
         insertWalSwitchXRecord(wal2);
 
         fillLastPage(wal2, DEFAULT_GDPB_XLOG_PAGE_SIZE);
@@ -470,7 +565,7 @@ testRun(void)
             Buffer *wal1 = bufNew(DEFAULT_GDPB_XLOG_PAGE_SIZE * 3);
             record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = DEFAULT_GDPB_XLOG_PAGE_SIZE * 3);
             hrnGpdbWalInsertXRecordP(
-                wal1, record, INCOMPLETE_RECORD, .beginOffset = DEFAULT_GDPB_XLOG_PAGE_SIZE * 2, .incompletePosition = 1);
+                wal1, record, INCOMPLETE_RECORD, .remLen = DEFAULT_GDPB_XLOG_PAGE_SIZE * 2, .incompletePosition = 1);
 
             record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = DEFAULT_GDPB_XLOG_PAGE_SIZE * 2);
             insertXRecord(wal1, record, INCOMPLETE_RECORD | OVERWRITE);
@@ -492,7 +587,7 @@ testRun(void)
         wal2 = bufNew(1024 * 1024);
         record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = DEFAULT_GDPB_XLOG_PAGE_SIZE * 2);
         insertXRecord(
-            wal2, record, NO_FLAGS, .segno = 2, .beginOffset = 32728 + 96);
+            wal2, record, NO_FLAGS, .segno = 2, .remLen = 32728 + 96);
         insertWalSwitchXRecord(wal2);
 
         fillLastPage(wal2, DEFAULT_GDPB_XLOG_PAGE_SIZE);
@@ -504,14 +599,14 @@ testRun(void)
             STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000001-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd");
         MEM_CONTEXT_TEMP_END();
 
-        TEST_TITLE("override record in the beginning of prev file");
+        TEST_TITLE("overwrite record in the beginning of prev file");
         MEM_CONTEXT_TEMP_BEGIN();
         filter = walFilterNew(pgControl, &archiveInfo);
         {
             Buffer *wal1 = bufNew(DEFAULT_GDPB_XLOG_PAGE_SIZE);
             record = createXRecord(
                 RM_XLOG_ID, XLOG_NOOP, .body_size = DEFAULT_GDPB_XLOG_PAGE_SIZE - SizeOfXLogLongPHD - SizeOfXLogRecordGPDB6 - 8);
-            insertXRecord(wal1, record, OVERWRITE, .beginOffset = 100);
+            insertXRecord(wal1, record, OVERWRITE, .remLen = 100);
 
             record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = 100);
             hrnGpdbWalInsertXRecordP(wal1, record, INCOMPLETE_RECORD);
@@ -524,7 +619,7 @@ testRun(void)
         }
         wal2 = bufNew(1024 * 1024);
         record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = 100);
-        insertXRecord(wal2, record, NO_FLAGS, .segno = 2, .beginOffset = 132 - 8);
+        insertXRecord(wal2, record, NO_FLAGS, .segno = 2, .remLen = 132 - 8);
         insertWalSwitchXRecord(wal2);
 
         fillLastPage(wal2, DEFAULT_GDPB_XLOG_PAGE_SIZE);
@@ -550,7 +645,7 @@ testRun(void)
 
         wal2 = bufNew(1024 * 1024);
         record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = 100);
-        hrnGpdbWalInsertXRecordP(wal2, record, NO_FLAGS, .segno = 2, .beginOffset = 132 - 8);
+        hrnGpdbWalInsertXRecordP(wal2, record, NO_FLAGS, .segno = 2, .remLen = 132 - 8);
         insertWalSwitchXRecord(wal2);
         fillLastPage(wal2, DEFAULT_GDPB_XLOG_PAGE_SIZE);
         result = testFilter(filter, wal2, bufSize(wal2), bufSize(wal2));
@@ -581,7 +676,7 @@ testRun(void)
 
         wal2 = bufNew(1024 * 1024);
         record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = 100);
-        hrnGpdbWalInsertXRecordP(wal2, record, NO_FLAGS, .segno = 10, .beginOffset = 132 - 8);
+        hrnGpdbWalInsertXRecordP(wal2, record, NO_FLAGS, .segno = 10, .remLen = 132 - 8);
         insertWalSwitchXRecord(wal2);
         fillLastPage(wal2, DEFAULT_GDPB_XLOG_PAGE_SIZE);
         result = testFilter(filter, wal2, bufSize(wal2), bufSize(wal2));
@@ -602,7 +697,7 @@ testRun(void)
 
         wal2 = bufNew(1024 * 1024);
         record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = 100);
-        hrnGpdbWalInsertXRecordP(wal2, record, INCOMPLETE_RECORD, .segno = 2, .beginOffset = 132 - 8);
+        hrnGpdbWalInsertXRecordP(wal2, record, INCOMPLETE_RECORD, .segno = 2, .remLen = 132 - 8);
         insertWalSwitchXRecord(wal2);
 
         fillLastPage(wal2, DEFAULT_GDPB_XLOG_PAGE_SIZE);
@@ -634,7 +729,7 @@ testRun(void)
 
         wal2 = bufNew(1024 * 1024);
         record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = 100);
-        insertXRecord(wal2, record, NO_FLAGS, .segno = 2, .beginOffset = 132 - 16);
+        insertXRecord(wal2, record, NO_FLAGS, .segno = 2, .remLen = 132 - 16);
         insertWalSwitchXRecord(wal2);
 
         fillLastPage(wal2, DEFAULT_GDPB_XLOG_PAGE_SIZE);
@@ -668,7 +763,7 @@ testRun(void)
 
         wal2 = bufNew(1024 * 1024);
         record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = DEFAULT_GDPB_XLOG_PAGE_SIZE * 2);
-        insertXRecord(wal2, record, 0, .segno = 2, .beginOffset = (DEFAULT_GDPB_XLOG_PAGE_SIZE * 2 + SizeOfXLogRecordGPDB6) - 8);
+        insertXRecord(wal2, record, 0, .segno = 2, .remLen = (DEFAULT_GDPB_XLOG_PAGE_SIZE * 2 + SizeOfXLogRecordGPDB6) - 8);
         insertWalSwitchXRecord(wal2);
 
         fillLastPage(wal2, DEFAULT_GDPB_XLOG_PAGE_SIZE);
@@ -713,7 +808,7 @@ testRun(void)
 
         wal2 = bufNew(1024 * 1024);
         record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = 100);
-        insertXRecord(wal2, record, 0, .segno = 2, .beginOffset = 132 - 8);
+        insertXRecord(wal2, record, 0, .segno = 2, .remLen = 132 - 8);
         insertWalSwitchXRecord(wal2);
 
         fillLastPage(wal2, DEFAULT_GDPB_XLOG_PAGE_SIZE);
@@ -756,7 +851,7 @@ testRun(void)
 
         wal2 = bufNew(1024 * 1024);
         record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = 100);
-        hrnGpdbWalInsertXRecordP(wal2, record, 0, .segno = 2, .beginOffset = 132 - 8);
+        hrnGpdbWalInsertXRecordP(wal2, record, 0, .segno = 2, .remLen = 132 - 8);
         insertWalSwitchXRecord(wal2);
 
         fillLastPage(wal2, DEFAULT_GDPB_XLOG_PAGE_SIZE);
@@ -790,7 +885,7 @@ testRun(void)
         // 40  32728 |24  32744 |24  16552 32 16160 |24  32744 |24  16600 32
         // LPH  RM   |SPH  RM   |SPH  RM   RH   B   |SPH  RM   |SPH  RM   RH
         record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = DEFAULT_GDPB_XLOG_PAGE_SIZE * 3);
-        insertXRecord(wal2, record, 0, .segno = 2, .beginOffset = 32728 + 32744 + 16552);
+        insertXRecord(wal2, record, 0, .segno = 2, .remLen = 32728 + 32744 + 16552);
         record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = DEFAULT_GDPB_XLOG_PAGE_SIZE * 2);
         insertXRecord(wal2, record, NO_FLAGS);
         insertWalSwitchXRecord(wal2);
@@ -843,7 +938,7 @@ testRun(void)
         record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = DEFAULT_GDPB_XLOG_PAGE_SIZE * 3);
         insertXRecord(
             wal2, record, INCOMPLETE_RECORD, .segno = 2,
-            .beginOffset = (DEFAULT_GDPB_XLOG_PAGE_SIZE * 3 + SizeOfXLogRecordGPDB6) - (SizeOfXLogRecordGPDB6 + 16280));
+            .remLen = (DEFAULT_GDPB_XLOG_PAGE_SIZE * 3 + SizeOfXLogRecordGPDB6) - (SizeOfXLogRecordGPDB6 + 16280));
         record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = DEFAULT_GDPB_XLOG_PAGE_SIZE * 2);
         insertXRecord(wal2, record, OVERWRITE, .segno = 2);
         insertWalSwitchXRecord(wal2);
@@ -855,6 +950,48 @@ testRun(void)
         HRN_STORAGE_REMOVE(
             storageRepoWrite(),
             STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000001-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd");
+        MEM_CONTEXT_TEMP_END();
+
+        TEST_TITLE("overwrite record in remaining data at the beginning without prev file");
+        MEM_CONTEXT_TEMP_BEGIN();
+        filter = walFilterNew(pgControl, &archiveInfo);
+
+        wal2 = bufNew(DEFAULT_GDPB_XLOG_PAGE_SIZE * 2);
+
+        record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = DEFAULT_GDPB_XLOG_PAGE_SIZE * 3);
+        insertXRecord(
+            wal2, record, INCOMPLETE_RECORD, .segno = 2,
+            .remLen = DEFAULT_GDPB_XLOG_PAGE_SIZE * 2);
+        record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = 100);
+        insertXRecord(wal2, record, OVERWRITE, .segno = 2);
+        insertWalSwitchXRecord(wal2);
+
+        fillLastPage(wal2, DEFAULT_GDPB_XLOG_PAGE_SIZE);
+        result = testFilter(filter, wal2, 1024 * 1024, 1024 * 1024);
+        TEST_RESULT_BOOL(bufEq(wal2, result), true, "WAL not the same");
+        TEST_RESULT_LOG("P00   WARN: 0/8000000 - Missing previous WAL file. Is current file is first in the chain?");
+
+        MEM_CONTEXT_TEMP_END();
+
+        TEST_TITLE("overwrite record in remaining data at the beginning without prev file on the second page");
+        MEM_CONTEXT_TEMP_BEGIN();
+        filter = walFilterNew(pgControl, &archiveInfo);
+
+        wal2 = bufNew(DEFAULT_GDPB_XLOG_PAGE_SIZE * 3);
+
+        record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = DEFAULT_GDPB_XLOG_PAGE_SIZE * 3);
+        insertXRecord(
+            wal2, record, INCOMPLETE_RECORD, .segno = 2,
+            .remLen = DEFAULT_GDPB_XLOG_PAGE_SIZE * 2, .incompletePosition = 1);
+        record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = 100);
+        insertXRecord(wal2, record, OVERWRITE, .segno = 2);
+        insertWalSwitchXRecord(wal2);
+
+        fillLastPage(wal2, DEFAULT_GDPB_XLOG_PAGE_SIZE);
+        result = testFilter(filter, wal2, 1024 * 1024, 1024 * 1024);
+        TEST_RESULT_BOOL(bufEq(wal2, result), true, "WAL not the same");
+        TEST_RESULT_LOG("P00   WARN: 0/8000000 - Missing previous WAL file. Is current file is first in the chain?");
+
         MEM_CONTEXT_TEMP_END();
 
         TEST_TITLE("long record at the end of the previous file with small buffer");
@@ -884,7 +1021,7 @@ testRun(void)
             record,
             0,
             .segno = 2,
-            .beginOffset = 32728 + 32744 + 16552);
+            .remLen = 32728 + 32744 + 16552);
         record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = DEFAULT_GDPB_XLOG_PAGE_SIZE * 2);
         insertXRecord(wal2, record, NO_FLAGS);
         insertWalSwitchXRecord(wal2);
@@ -921,8 +1058,7 @@ testRun(void)
 
         archiveInfo.cipherType = cipherTypeAes256Cbc;
         archiveInfo.cipherPassArchive = STRDEF(TEST_CIPHER_PASS_ARCHIVE);
-        archiveInfo.file = STRDEF(
-            STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000002-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd.gz");
+        archiveInfo.file = STRDEF(".gz");
 
         filter = walFilterNew(pgControl, &archiveInfo);
         {
@@ -947,7 +1083,7 @@ testRun(void)
 
         wal2 = bufNew(1024 * 1024);
         record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = 100);
-        insertXRecord(wal2, record, 0, .segno = 2, .beginOffset = 132 - 8);
+        insertXRecord(wal2, record, 0, .segno = 2, .remLen = 132 - 8);
         insertWalSwitchXRecord(wal2);
 
         fillLastPage(wal2, DEFAULT_GDPB_XLOG_PAGE_SIZE);
@@ -996,8 +1132,7 @@ testRun(void)
 
         HRN_STORAGE_PATH_CREATE(storageRepoIdxWrite(0), STORAGE_REPO_ARCHIVE "/9.4-1");
         ArchiveGetFile archiveInfo = {
-            .file = STRDEF(
-                STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000001-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"),
+            .file = STRDEF(""),
             .repoIdx = 0,
             .archiveId = STRDEF("9.4-1"),
             .cipherType = cipherTypeNone,
@@ -1013,7 +1148,7 @@ testRun(void)
             Buffer *wal1 = bufNew(DEFAULT_GDPB_XLOG_PAGE_SIZE);
 
             record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = 100);
-            insertXRecord(wal1, record, 0, .beginOffset = 100);
+            insertXRecord(wal1, record, 0, .remLen = 100);
             fillLastPage(wal1, DEFAULT_GDPB_XLOG_PAGE_SIZE);
 
             HRN_STORAGE_PUT(
@@ -1041,6 +1176,42 @@ testRun(void)
             STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000002-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd");
         MEM_CONTEXT_TEMP_END();
 
+        TEST_TITLE("last record is switch wal");
+        MEM_CONTEXT_TEMP_BEGIN();
+        PgControl testPgControl = pgControl;
+        testPgControl.walSegmentSize = DEFAULT_GDPB_XLOG_PAGE_SIZE;
+        filter = walFilterNew(testPgControl, &archiveInfo);
+        {
+            Buffer *wal1 = bufNew(DEFAULT_GDPB_XLOG_PAGE_SIZE);
+
+            record = createXRecord(RM_XLOG_ID, XLOG_SWITCH);
+            insertXRecord(wal1, record, 0, .remLen = SizeOfXLogRecordGPDB6 - 16);
+            fillLastPage(wal1, DEFAULT_GDPB_XLOG_PAGE_SIZE);
+
+            HRN_STORAGE_PUT(
+                storageRepoWrite(),
+                STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000002-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
+                wal1);
+        }
+
+        wal2 = bufNew(DEFAULT_GDPB_XLOG_PAGE_SIZE);
+        record = createXRecord(
+            RM_XLOG_ID,
+            XLOG_NOOP,
+            .body_size = calcBodySize(1, 16, 0, DEFAULT_GDPB_XLOG_PAGE_SIZE));
+        insertXRecord(wal2, record, NO_FLAGS, .segno = 1, .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE);
+        record = createXRecord(RM_XLOG_ID, XLOG_SWITCH);
+        insertXRecord(wal2, record, INCOMPLETE_RECORD, .segno = 1, .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE);
+
+        fillLastPage(wal2, DEFAULT_GDPB_XLOG_PAGE_SIZE);
+        result = testFilter(filter, wal2, bufSize(wal2), bufSize(wal2));
+        TEST_RESULT_BOOL(bufEq(wal2, result), true, "WAL not the same");
+
+        HRN_STORAGE_REMOVE(
+            storageRepoWrite(),
+            STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000002-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd");
+        MEM_CONTEXT_TEMP_END();
+
         TEST_TITLE("the next file is partial");
         MEM_CONTEXT_TEMP_BEGIN();
         PgControl testPgControl = pgControl;
@@ -1050,7 +1221,7 @@ testRun(void)
             Buffer *wal1 = bufNew(DEFAULT_GDPB_XLOG_PAGE_SIZE);
 
             record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = 100);
-            insertXRecord(wal1, record, 0, .beginOffset = 100);
+            insertXRecord(wal1, record, 0, .remLen = 100);
             fillLastPage(wal1, DEFAULT_GDPB_XLOG_PAGE_SIZE);
 
             HRN_STORAGE_PUT(
@@ -1104,7 +1275,7 @@ testRun(void)
                 wal1,
                 record,
                 0,
-                .beginOffset = getRemainingLenOnPage(record, 2, DEFAULT_GDPB_XLOG_PAGE_SIZE, recordLsn),
+                .remLen = getRemainingLenOnPage(record, 2, DEFAULT_GDPB_XLOG_PAGE_SIZE, recordLsn),
                 .segno = 2,
                 .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE);
             insertWalSwitchXRecord(wal1);
@@ -1120,7 +1291,7 @@ testRun(void)
                 wal1_partial,
                 record,
                 0,
-                .beginOffset = getRemainingLenOnPage(record, 2, DEFAULT_GDPB_XLOG_PAGE_SIZE, recordLsn),
+                .remLen = getRemainingLenOnPage(record, 2, DEFAULT_GDPB_XLOG_PAGE_SIZE, recordLsn),
                 .segno = 2,
                 .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE);
             // There is no wal switch and there is garbage after an unfinished record.
@@ -1150,7 +1321,7 @@ testRun(void)
             Buffer *wal1 = bufNew(DEFAULT_GDPB_XLOG_PAGE_SIZE);
 
             record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = 100);
-            insertXRecord(wal1, record, 0, .beginOffset = 100, .segno = 63);
+            insertXRecord(wal1, record, 0, .remLen = 100, .segno = 63);
             fillLastPage(wal1, DEFAULT_GDPB_XLOG_PAGE_SIZE);
 
             HRN_STORAGE_PUT(
@@ -1210,7 +1381,7 @@ testRun(void)
             Buffer *wal1 = bufNew(DEFAULT_GDPB_XLOG_PAGE_SIZE);
 
             record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = 100);
-            insertXRecord(wal1, record, 0, .beginOffset = 100, .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE);
+            insertXRecord(wal1, record, 0, .remLen = 100, .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE);
             fillLastPage(wal1, DEFAULT_GDPB_XLOG_PAGE_SIZE);
 
             Buffer *zeros = bufNew(DEFAULT_GDPB_XLOG_PAGE_SIZE);
@@ -1298,7 +1469,7 @@ testRun(void)
 
             record = createXRecord(
                 RM_XLOG_ID, XLOG_NOOP, .body_size = DEFAULT_GDPB_XLOG_PAGE_SIZE * 2 - SizeOfXLogRecordGPDB6);
-            insertXRecord(wal1, record, 0, .beginOffset = DEFAULT_GDPB_XLOG_PAGE_SIZE * 2 - SizeOfXLogRecordGPDB6, .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE * 3);
+            insertXRecord(wal1, record, 0, .remLen = DEFAULT_GDPB_XLOG_PAGE_SIZE * 2 - SizeOfXLogRecordGPDB6, .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE * 3);
             fillLastPage(wal1, DEFAULT_GDPB_XLOG_PAGE_SIZE);
 
             HRN_STORAGE_PUT(
@@ -1342,7 +1513,7 @@ testRun(void)
             // 40  32 32696 |24  72 32 32640 |24 32744
             // LPH RH   B   |SPH B  RH   B   |PH   B
             // DEFAULT_GDPB_XLOG_PAGE_SIZE * 4 - 32640 - 32744 = 65688
-            insertXRecord(wal1, record, 0, .beginOffset = 65688, .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE * 3);
+            insertXRecord(wal1, record, 0, .remLen = 65688, .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE * 3);
             fillLastPage(wal1, DEFAULT_GDPB_XLOG_PAGE_SIZE);
 
             HRN_STORAGE_PUT(
@@ -1374,7 +1545,7 @@ testRun(void)
             Buffer *wal1 = bufNew(DEFAULT_GDPB_XLOG_PAGE_SIZE * 3);
 
             record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = (DEFAULT_GDPB_XLOG_PAGE_SIZE * 2) - SizeOfXLogRecordGPDB6);
-            insertXRecord(wal1, record, 0, .beginOffset = (DEFAULT_GDPB_XLOG_PAGE_SIZE * 2) - SizeOfXLogRecordGPDB6);
+            insertXRecord(wal1, record, 0, .remLen = (DEFAULT_GDPB_XLOG_PAGE_SIZE * 2) - SizeOfXLogRecordGPDB6);
             fillLastPage(wal1, DEFAULT_GDPB_XLOG_PAGE_SIZE);
             bufResize(wal1, DEFAULT_GDPB_XLOG_PAGE_SIZE * 2);
             HRN_STORAGE_PUT(
@@ -1420,7 +1591,7 @@ testRun(void)
             // 40  124
             // LPH  RM
             record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = 100);
-            insertXRecord(wal1, record, 0, .beginOffset = 124, .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE);
+            insertXRecord(wal1, record, 0, .remLen = 124, .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE);
             fillLastPage(wal1, DEFAULT_GDPB_XLOG_PAGE_SIZE);
 
             HRN_STORAGE_PUT(
@@ -1474,7 +1645,7 @@ testRun(void)
                 wals[i],
                 record,
                 INCOMPLETE_RECORD,
-                .beginOffset = getRemainingLenOnPage(record, i * 2 + 1, DEFAULT_GDPB_XLOG_PAGE_SIZE * 2, 0),
+                .remLen = getRemainingLenOnPage(record, i * 2 + 1, DEFAULT_GDPB_XLOG_PAGE_SIZE * 2, 0),
                 .incompletePosition = 1,
                 .segno = i + 1,
                 .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE * 2);
@@ -1491,7 +1662,7 @@ testRun(void)
             wals[4],
             record,
             NO_FLAGS,
-            .beginOffset = getRemainingLenOnPage(record, 9, DEFAULT_GDPB_XLOG_PAGE_SIZE * 2, 0),
+            .remLen = getRemainingLenOnPage(record, 9, DEFAULT_GDPB_XLOG_PAGE_SIZE * 2, 0),
             .segno = 5,
             .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE * 2);
         insertWalSwitchXRecord(wals[4]);
@@ -1540,7 +1711,7 @@ testRun(void)
                 wals[i],
                 record,
                 INCOMPLETE_RECORD,
-                .beginOffset = getRemainingLenOnPage(record, i * 2 + 1, DEFAULT_GDPB_XLOG_PAGE_SIZE * 2, 0),
+                .remLen = getRemainingLenOnPage(record, i * 2 + 1, DEFAULT_GDPB_XLOG_PAGE_SIZE * 2, 0),
                 .incompletePosition = 1,
                 .segno = i + 1,
                 .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE * 2);
@@ -1558,7 +1729,7 @@ testRun(void)
             wals[64],
             record,
             NO_FLAGS,
-            .beginOffset = getRemainingLenOnPage(record, 129, DEFAULT_GDPB_XLOG_PAGE_SIZE * 2, 0),
+            .remLen = getRemainingLenOnPage(record, 129, DEFAULT_GDPB_XLOG_PAGE_SIZE * 2, 0),
             .segno = LENGTH_OF(wals) - 1,
             .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE * 2);
         insertWalSwitchXRecord(wals[64]);
@@ -1585,6 +1756,27 @@ testRun(void)
 
         MEM_CONTEXT_TEMP_END();
 
+        TEST_TITLE("whole WAL file is incomplete record");
+
+        MEM_CONTEXT_TEMP_BEGIN();
+
+        PgControl testPgControl = pgControl;
+        testPgControl.walSegmentSize = DEFAULT_GDPB_XLOG_PAGE_SIZE * 3;
+
+        Buffer *wal1 = bufNew(DEFAULT_GDPB_XLOG_PAGE_SIZE * 3);
+
+        record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = DEFAULT_GDPB_XLOG_PAGE_SIZE * 10);
+        insertXRecord(wal1, record, INCOMPLETE_RECORD, .segno = 1, .remLen = DEFAULT_GDPB_XLOG_PAGE_SIZE * 8, .incompletePosition = 2);
+
+        {
+            filter = walFilterNew(testPgControl, &archiveInfo);
+            result = testFilter(filter, wal1, bufSize(wal1), bufSize(wal1));
+            TEST_RESULT_BOOL(bufEq(wal1, result), true, "WAL not the same");
+            TEST_RESULT_LOG("P00   WARN: 0/4000000 - Missing previous WAL file. Is current file is first in the chain?");
+        }
+
+        MEM_CONTEXT_TEMP_END();
+
         TEST_TITLE("incomplete end of record in the next partial file");
         // If there is an unfinished record at the end of the segment, we need to read the next file. This file may be partial if
         // the timeline has been switched in it. In this case, we have no guarantee that the end of the record will be complete, and
@@ -1607,7 +1799,7 @@ testRun(void)
                 wal2,
                 record,
                 INCOMPLETE_RECORD,
-                .beginOffset = getRemainingLenOnPage(record, 2, DEFAULT_GDPB_XLOG_PAGE_SIZE * 3, bufUsed(wal1)),
+                .remLen = getRemainingLenOnPage(record, 2, DEFAULT_GDPB_XLOG_PAGE_SIZE * 3, bufUsed(wal1)),
                 .segno = 2,
                 .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE * 3);
             memset(bufRemainsPtr(wal2), 0xFF, bufRemains(wal2));
@@ -1664,7 +1856,7 @@ testRun(void)
             Buffer *wal1 = bufNew(DEFAULT_GDPB_XLOG_PAGE_SIZE);
 
             record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = 100);
-            insertXRecord(wal1, record, 0, .beginOffset = 100, .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE);
+            insertXRecord(wal1, record, 0, .remLen = 100, .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE);
             fillLastPage(wal1, DEFAULT_GDPB_XLOG_PAGE_SIZE);
 
             HRN_STORAGE_PUT(
@@ -1813,7 +2005,7 @@ testRun(void)
         TEST_RESULT_BOOL(bufEq(wal, result), true, "WAL not the same");
         MEM_CONTEXT_TEMP_END();
 
-        TEST_TITLE("override record in header");
+        TEST_TITLE("overwrite record in header");
         MEM_CONTEXT_TEMP_BEGIN();
         filter = walFilterNew(pgControl, NULL);
         {
@@ -1834,7 +2026,7 @@ testRun(void)
         TEST_RESULT_BOOL(bufEq(wal, result), true, "WAL not the same");
         MEM_CONTEXT_TEMP_END();
 
-        TEST_TITLE("override record in body");
+        TEST_TITLE("overwrite record in body");
         MEM_CONTEXT_TEMP_BEGIN();
         filter = walFilterNew(pgControl, NULL);
         {
@@ -1856,7 +2048,7 @@ testRun(void)
         TEST_RESULT_BOOL(bufEq(wal, result), true, "WAL not the same");
         MEM_CONTEXT_TEMP_END();
 
-        TEST_TITLE("override record in long body");
+        TEST_TITLE("overwrite record in long body");
         MEM_CONTEXT_TEMP_BEGIN();
         filter = walFilterNew(pgControl, NULL);
         {
@@ -1876,13 +2068,13 @@ testRun(void)
         TEST_RESULT_BOOL(bufEq(wal, result), true, "WAL not the same");
         MEM_CONTEXT_TEMP_END();
 
-        TEST_TITLE("override record at the beginning");
+        TEST_TITLE("overwrite record at the beginning");
         MEM_CONTEXT_TEMP_BEGIN();
         filter = walFilterNew(pgControl, NULL);
         {
             wal = bufNew(1024 * 1024);
             record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = 100);
-            insertXRecord(wal, record, OVERWRITE, .beginOffset = 100);
+            insertXRecord(wal, record, OVERWRITE, .remLen = 100);
             XRecordInfo walRecords[] = {
                 {RM_XLOG_ID, XLOG_NOOP, 100}
             };
@@ -2442,10 +2634,7 @@ testRun(void)
         TEST_TITLE("filter record when begin or end of the record is in the other file");
 
         ArchiveGetFile archiveInfo = {
-            .file =
-                STRDEF(
-                    STORAGE_REPO_ARCHIVE
-                    "/9.4-1/0000000100000000/000000010000000000000002-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"),
+            .file = STRDEF(""),
             .repoIdx = 0,
             .archiveId = STRDEF("9.4-1"),
             .cipherType = cipherTypeNone,
@@ -2515,7 +2704,7 @@ testRun(void)
             // 32 + 12 = 44
             // 44 - 8 = 36
             record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = sizeof(node2), .body = &node2);
-            insertXRecord(wal4, record, 0, .beginOffset = 36, .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE);
+            insertXRecord(wal4, record, 0, .remLen = 36, .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE);
             HRN_STORAGE_PUT(
                 storageRepoWrite(),
                 STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000003-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
@@ -2534,7 +2723,7 @@ testRun(void)
             // 40  36 4 32 32644 4 8  |
             // LPH RM P RH   B   P RH |
             record = createXRecord(RM6_HEAP_ID, XLOG_HEAP_INSERT, .body_size = sizeof(node1), .body = &node1);
-            insertXRecord(wal2, record, 0, .segno = 2, .beginOffset = (sizeof(node1) + SizeOfXLogRecordGPDB6) - 8, .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE);
+            insertXRecord(wal2, record, 0, .segno = 2, .remLen = (sizeof(node1) + SizeOfXLogRecordGPDB6) - 8, .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE);
             record = createXRecord(
                 RM_XLOG_ID,
                 XLOG_NOOP,
@@ -2563,7 +2752,7 @@ testRun(void)
             // 40  36 4 32 32644 4 8  |
             // LPH RM P RH   B   P RH |
             record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = sizeof(node1), .body = &node1);
-            insertXRecord(wal3, record, 0, .segno = 2, .beginOffset = (sizeof(node1) + SizeOfXLogRecordGPDB6) - 8, .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE);
+            insertXRecord(wal3, record, 0, .segno = 2, .remLen = (sizeof(node1) + SizeOfXLogRecordGPDB6) - 8, .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE);
             record = createXRecord(
                 RM_XLOG_ID,
                 XLOG_NOOP,
@@ -2644,7 +2833,7 @@ testRun(void)
             // 40  28 32
             // LPH RM RH
             record = createXRecord(RM6_HEAP_ID, XLOG_HEAP_INSERT, .body_size = sizeof(node1), .body = &node1);
-            insertXRecord(wal2, record, NO_FLAGS, .segno = 2, .beginOffset = 28, .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE);
+            insertXRecord(wal2, record, NO_FLAGS, .segno = 2, .remLen = 28, .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE);
             insertWalSwitchXRecord(wal2);
             fillLastPage(wal2, DEFAULT_GDPB_XLOG_PAGE_SIZE);
             HRN_STORAGE_PUT(
@@ -2681,7 +2870,7 @@ testRun(void)
             // 40  28 32
             // LPH RM RH
             record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = sizeof(node1), .body = &node1);
-            insertXRecord(wal2_expected, record, NO_FLAGS, .segno = 2, .beginOffset = 28, .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE);
+            insertXRecord(wal2_expected, record, NO_FLAGS, .segno = 2, .remLen = 28, .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE);
             insertWalSwitchXRecord(wal2_expected);
             fillLastPage(wal2_expected, DEFAULT_GDPB_XLOG_PAGE_SIZE);
         }
@@ -2691,16 +2880,10 @@ testRun(void)
         {
             HRN_FORK_CHILD_BEGIN()
             {
-                archiveInfo.file = STRDEF(
-                    STORAGE_REPO_ARCHIVE
-                    "/9.4-1/0000000100000000/000000010000000000000001-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd");
                 filter = walFilterNew(testPgControl, &archiveInfo);
                 result = testFilter(filter, wal1, bufSize(wal1), bufSize(wal1));
                 TEST_RESULT_BOOL(bufEq(wal1_expected, result), true, "WAL not the same");
 
-                archiveInfo.file = STRDEF(
-                    STORAGE_REPO_ARCHIVE
-                    "/9.4-1/0000000100000000/000000010000000000000002-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd");
                 filter = walFilterNew(testPgControl, &archiveInfo);
                 result = testFilter(filter, wal2, bufSize(wal2), bufSize(wal2));
                 TEST_RESULT_BOOL(bufEq(wal2_expected, result), true, "WAL not the same");
@@ -2765,9 +2948,6 @@ testRun(void)
         {
             HRN_FORK_CHILD_BEGIN()
             {
-                archiveInfo.file = STRDEF(
-                    STORAGE_REPO_ARCHIVE
-                    "/9.4-1/0000000100000000/000000010000000000000001-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd");
                 filter = walFilterNew(testPgControl, &archiveInfo);
                 result = testFilter(filter, wal1, bufSize(wal1), bufSize(wal1));
                 TEST_RESULT_BOOL(bufEq(wal1, result), true, "WAL not the same");
@@ -2827,7 +3007,7 @@ testRun(void)
             // LPH  RM   |SPH RH  B  RH
             // DEFAULT_GDPB_XLOG_PAGE_SIZE * 3 - 16 = 98288
             record = createXRecord(RM6_HEAP_ID, XLOG_HEAP_INSERT, .body_size = (uint32) bufUsed(bodyBuf), .body = bufPtr(bodyBuf));
-            insertXRecord(wal2, record, INCOMPLETE_RECORD, .segno = 2, .beginOffset = 98288, .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE * 2);
+            insertXRecord(wal2, record, INCOMPLETE_RECORD, .segno = 2, .remLen = 98288, .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE * 2);
             record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = 100);
             insertXRecord(wal2, record, OVERWRITE, .segno = 2, .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE * 2);
             insertWalSwitchXRecord(wal2);
@@ -2843,9 +3023,6 @@ testRun(void)
         {
             HRN_FORK_CHILD_BEGIN()
             {
-                archiveInfo.file = STRDEF(
-                    STORAGE_REPO_ARCHIVE
-                    "/9.4-1/0000000100000000/000000010000000000000001-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd");
                 filter = walFilterNew(testPgControl, &archiveInfo);
                 result = testFilter(filter, wal1, bufSize(wal1), bufSize(wal1));
                 TEST_RESULT_BOOL(bufEq(wal1, result), true, "WAL not the same");
@@ -3162,6 +3339,66 @@ testRun(void)
         MEM_CONTEXT_TEMP_END();
     }
 
+    if (testBegin("brute force test"))
+    {
+        HRN_STORAGE_PUT_Z(storageTest, "recovery_filter.json", "[]");
+        const uint32 recordBodySizeSize = 128 * 1024;
+        const uint32 walSize = 512 * 1024;
+        const PgControl pgControl = {
+            .version = PG_VERSION_94,
+            .pageSize = DEFAULT_GDPB_PAGE_SIZE,
+            .walPageSize = DEFAULT_GDPB_XLOG_PAGE_SIZE,
+            .walSegmentSize = walSize
+        };
+        const ArchiveGetFile archiveInfo = {
+            .file = STRDEF(""), // this field is used to determine compression algorithm
+            .repoIdx = 0,
+            .archiveId = STRDEF("9.4-1"),
+            .cipherType = cipherTypeNone,
+            .cipherPassArchive = STRDEF("")
+        };
+        Buffer *wal = bufNew(walSize);
+        srand(123);
+        record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = recordBodySizeSize);
+
+        for (uint32 offset = 0; offset <= DEFAULT_GDPB_XLOG_PAGE_SIZE * 2; offset += MAXIMUM_ALIGNOF)
+        {
+            MEM_CONTEXT_TEMP_BEGIN();
+            bool consumeLog = false;
+            if (offset % DEFAULT_GDPB_XLOG_PAGE_SIZE == 0)
+            {
+                if (offset == 0)
+                    offset += SizeOfXLogLongPHD;
+                else
+                    offset += SizeOfXLogShortPHD;
+            }
+            // For the first 256 bytes, instead of filling the beginning of the WAL file with records, we create one unfinished
+            // record. To test the unfinished records at the beginning.
+            if (offset > SizeOfXLogLongPHD && offset < 256)
+            {
+                XLogRecordBase *fillRecord = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = DEFAULT_GDPB_XLOG_PAGE_SIZE);
+                insertXRecord(wal, fillRecord, NO_FLAGS, .segno = 1, .remLen = (uint32) (offset - SizeOfXLogLongPHD), .segSize = walSize);
+                consumeLog = true;
+            }
+            else
+            {
+                fillWalWithRecords(wal, offset, walSize);
+            }
+
+            insertXRecord(wal, record, NO_FLAGS, .segno = 1, .segSize = walSize);
+            fillWalWithRecords(wal, walSize, walSize);
+
+            filter = walFilterNew(pgControl, &archiveInfo);
+            result = testFilter(filter, wal, 128 * 1024, 128 * 1024);
+            TEST_RESULT_BOOL(bufEq(wal, result), true, "WAL not the same");
+            if (consumeLog)
+                TEST_RESULT_LOG("P00   WARN: 0/80000 - Missing previous WAL file. Is current file is first in the chain?");
+
+            MEM_CONTEXT_TEMP_END();
+            bufUsedSet(wal, 0);
+        }
+    }
+
     if (testBegin("Unsupported GPDB version"))
     {
         PgControl pgControl = {
@@ -3186,6 +3423,5 @@ testRun(void)
             walFilterNew(pgControl, NULL),
             VersionNotSupportedError, "WAL filtering is only supported for GPDB 6 and 7");
     }
-
     FUNCTION_HARNESS_RETURN_VOID();
 }

--- a/test/src/module/common/walFilterGPDB6Test.c
+++ b/test/src/module/common/walFilterGPDB6Test.c
@@ -194,6 +194,7 @@ fillWalWithRecords(Buffer *wal, uint32 targetOffset, uint32 segSize)
         return;
     }
 
+    ASSERT(targetOffset > bufUsed(wal));
     // We stop when we get close to the target offset by the page size.
     while (targetOffset - bufUsed(wal) > DEFAULT_GDPB_XLOG_PAGE_SIZE)
     {
@@ -311,7 +312,7 @@ testRun(void)
         archiveInfo.file = STRDEF("");
         MEM_CONTEXT_TEMP_END();
 
-        TEST_TITLE("an unfinished recprd at the beginning of the file is a wal switch");
+        TEST_TITLE("an unfinished record at the beginning of the file is a wal switch");
         MEM_CONTEXT_TEMP_BEGIN();
         filter = walFilterNew(pgControl, &archiveInfo);
         {
@@ -763,7 +764,7 @@ testRun(void)
 
         wal2 = bufNew(1024 * 1024);
         record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = DEFAULT_GDPB_XLOG_PAGE_SIZE * 2);
-        insertXRecord(wal2, record, 0, .segno = 2, .remLen = (DEFAULT_GDPB_XLOG_PAGE_SIZE * 2 + SizeOfXLogRecordGPDB6) - 8);
+        insertXRecord(wal2, record, NO_FLAGS, .segno = 2, .remLen = (DEFAULT_GDPB_XLOG_PAGE_SIZE * 2 + SizeOfXLogRecordGPDB6) - 8);
         insertWalSwitchXRecord(wal2);
 
         fillLastPage(wal2, DEFAULT_GDPB_XLOG_PAGE_SIZE);
@@ -808,7 +809,7 @@ testRun(void)
 
         wal2 = bufNew(1024 * 1024);
         record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = 100);
-        insertXRecord(wal2, record, 0, .segno = 2, .remLen = 132 - 8);
+        insertXRecord(wal2, record, NO_FLAGS, .segno = 2, .remLen = 132 - 8);
         insertWalSwitchXRecord(wal2);
 
         fillLastPage(wal2, DEFAULT_GDPB_XLOG_PAGE_SIZE);
@@ -851,7 +852,7 @@ testRun(void)
 
         wal2 = bufNew(1024 * 1024);
         record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = 100);
-        hrnGpdbWalInsertXRecordP(wal2, record, 0, .segno = 2, .remLen = 132 - 8);
+        hrnGpdbWalInsertXRecordP(wal2, record, NO_FLAGS, .segno = 2, .remLen = 132 - 8);
         insertWalSwitchXRecord(wal2);
 
         fillLastPage(wal2, DEFAULT_GDPB_XLOG_PAGE_SIZE);
@@ -885,7 +886,7 @@ testRun(void)
         // 40  32728 |24  32744 |24  16552 32 16160 |24  32744 |24  16600 32
         // LPH  RM   |SPH  RM   |SPH  RM   RH   B   |SPH  RM   |SPH  RM   RH
         record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = DEFAULT_GDPB_XLOG_PAGE_SIZE * 3);
-        insertXRecord(wal2, record, 0, .segno = 2, .remLen = 32728 + 32744 + 16552);
+        insertXRecord(wal2, record, NO_FLAGS, .segno = 2, .remLen = 32728 + 32744 + 16552);
         record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = DEFAULT_GDPB_XLOG_PAGE_SIZE * 2);
         insertXRecord(wal2, record, NO_FLAGS);
         insertWalSwitchXRecord(wal2);
@@ -1019,7 +1020,7 @@ testRun(void)
         insertXRecord(
             wal2,
             record,
-            0,
+            NO_FLAGS,
             .segno = 2,
             .remLen = 32728 + 32744 + 16552);
         record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = DEFAULT_GDPB_XLOG_PAGE_SIZE * 2);
@@ -1083,7 +1084,7 @@ testRun(void)
 
         wal2 = bufNew(1024 * 1024);
         record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = 100);
-        insertXRecord(wal2, record, 0, .segno = 2, .remLen = 132 - 8);
+        insertXRecord(wal2, record, NO_FLAGS, .segno = 2, .remLen = 132 - 8);
         insertWalSwitchXRecord(wal2);
 
         fillLastPage(wal2, DEFAULT_GDPB_XLOG_PAGE_SIZE);
@@ -1148,7 +1149,7 @@ testRun(void)
             Buffer *wal1 = bufNew(DEFAULT_GDPB_XLOG_PAGE_SIZE);
 
             record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = 100);
-            insertXRecord(wal1, record, 0, .remLen = 100);
+            insertXRecord(wal1, record, NO_FLAGS, .remLen = 100);
             fillLastPage(wal1, DEFAULT_GDPB_XLOG_PAGE_SIZE);
 
             HRN_STORAGE_PUT(
@@ -1185,7 +1186,7 @@ testRun(void)
             Buffer *wal1 = bufNew(DEFAULT_GDPB_XLOG_PAGE_SIZE);
 
             record = createXRecord(RM_XLOG_ID, XLOG_SWITCH);
-            insertXRecord(wal1, record, 0, .remLen = SizeOfXLogRecordGPDB6 - 16);
+            insertXRecord(wal1, record, NO_FLAGS, .remLen = SizeOfXLogRecordGPDB6 - 16);
             fillLastPage(wal1, DEFAULT_GDPB_XLOG_PAGE_SIZE);
 
             HRN_STORAGE_PUT(
@@ -1221,7 +1222,7 @@ testRun(void)
             Buffer *wal1 = bufNew(DEFAULT_GDPB_XLOG_PAGE_SIZE);
 
             record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = 100);
-            insertXRecord(wal1, record, 0, .remLen = 100);
+            insertXRecord(wal1, record, NO_FLAGS, .remLen = 100);
             fillLastPage(wal1, DEFAULT_GDPB_XLOG_PAGE_SIZE);
 
             HRN_STORAGE_PUT(
@@ -1274,7 +1275,7 @@ testRun(void)
             insertXRecord(
                 wal1,
                 record,
-                0,
+                NO_FLAGS,
                 .remLen = getRemainingLenOnPage(record, 2, DEFAULT_GDPB_XLOG_PAGE_SIZE, recordLsn),
                 .segno = 2,
                 .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE);
@@ -1290,7 +1291,7 @@ testRun(void)
             insertXRecord(
                 wal1_partial,
                 record,
-                0,
+                NO_FLAGS,
                 .remLen = getRemainingLenOnPage(record, 2, DEFAULT_GDPB_XLOG_PAGE_SIZE, recordLsn),
                 .segno = 2,
                 .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE);
@@ -1381,7 +1382,7 @@ testRun(void)
             Buffer *wal1 = bufNew(DEFAULT_GDPB_XLOG_PAGE_SIZE);
 
             record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = 100);
-            insertXRecord(wal1, record, 0, .remLen = 100, .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE);
+            insertXRecord(wal1, record, NO_FLAGS, .remLen = 100, .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE);
             fillLastPage(wal1, DEFAULT_GDPB_XLOG_PAGE_SIZE);
 
             Buffer *zeros = bufNew(DEFAULT_GDPB_XLOG_PAGE_SIZE);
@@ -1469,7 +1470,7 @@ testRun(void)
 
             record = createXRecord(
                 RM_XLOG_ID, XLOG_NOOP, .body_size = DEFAULT_GDPB_XLOG_PAGE_SIZE * 2 - SizeOfXLogRecordGPDB6);
-            insertXRecord(wal1, record, 0, .remLen = DEFAULT_GDPB_XLOG_PAGE_SIZE * 2 - SizeOfXLogRecordGPDB6, .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE * 3);
+            insertXRecord(wal1, record, NO_FLAGS, .remLen = DEFAULT_GDPB_XLOG_PAGE_SIZE * 2 - SizeOfXLogRecordGPDB6, .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE * 3);
             fillLastPage(wal1, DEFAULT_GDPB_XLOG_PAGE_SIZE);
 
             HRN_STORAGE_PUT(
@@ -1513,7 +1514,7 @@ testRun(void)
             // 40  32 32696 |24  72 32 32640 |24 32744
             // LPH RH   B   |SPH B  RH   B   |PH   B
             // DEFAULT_GDPB_XLOG_PAGE_SIZE * 4 - 32640 - 32744 = 65688
-            insertXRecord(wal1, record, 0, .remLen = 65688, .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE * 3);
+            insertXRecord(wal1, record, NO_FLAGS, .remLen = 65688, .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE * 3);
             fillLastPage(wal1, DEFAULT_GDPB_XLOG_PAGE_SIZE);
 
             HRN_STORAGE_PUT(
@@ -1545,7 +1546,7 @@ testRun(void)
             Buffer *wal1 = bufNew(DEFAULT_GDPB_XLOG_PAGE_SIZE * 3);
 
             record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = (DEFAULT_GDPB_XLOG_PAGE_SIZE * 2) - SizeOfXLogRecordGPDB6);
-            insertXRecord(wal1, record, 0, .remLen = (DEFAULT_GDPB_XLOG_PAGE_SIZE * 2) - SizeOfXLogRecordGPDB6);
+            insertXRecord(wal1, record, NO_FLAGS, .remLen = (DEFAULT_GDPB_XLOG_PAGE_SIZE * 2) - SizeOfXLogRecordGPDB6);
             fillLastPage(wal1, DEFAULT_GDPB_XLOG_PAGE_SIZE);
             bufResize(wal1, DEFAULT_GDPB_XLOG_PAGE_SIZE * 2);
             HRN_STORAGE_PUT(
@@ -1591,7 +1592,7 @@ testRun(void)
             // 40  124
             // LPH  RM
             record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = 100);
-            insertXRecord(wal1, record, 0, .remLen = 124, .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE);
+            insertXRecord(wal1, record, NO_FLAGS, .remLen = 124, .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE);
             fillLastPage(wal1, DEFAULT_GDPB_XLOG_PAGE_SIZE);
 
             HRN_STORAGE_PUT(
@@ -1856,7 +1857,7 @@ testRun(void)
             Buffer *wal1 = bufNew(DEFAULT_GDPB_XLOG_PAGE_SIZE);
 
             record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = 100);
-            insertXRecord(wal1, record, 0, .remLen = 100, .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE);
+            insertXRecord(wal1, record, NO_FLAGS, .remLen = 100, .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE);
             fillLastPage(wal1, DEFAULT_GDPB_XLOG_PAGE_SIZE);
 
             HRN_STORAGE_PUT(
@@ -2189,7 +2190,7 @@ testRun(void)
             wal = bufNew(1024 * 1024);
             record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = 100);
 
-            hrnGpdbWalInsertXRecordP(wal, record, 0, .magic = 0xDEAD);
+            hrnGpdbWalInsertXRecordP(wal, record, NO_FLAGS, .magic = 0xDEAD);
             fillLastPage(wal, DEFAULT_GDPB_XLOG_PAGE_SIZE);
         }
         TEST_ERROR(testFilter(filter, wal, bufSize(wal), bufSize(wal)), FormatError, "0/0 - wrong page magic");
@@ -2704,7 +2705,7 @@ testRun(void)
             // 32 + 12 = 44
             // 44 - 8 = 36
             record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = sizeof(node2), .body = &node2);
-            insertXRecord(wal4, record, 0, .remLen = 36, .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE);
+            insertXRecord(wal4, record, NO_FLAGS, .remLen = 36, .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE);
             HRN_STORAGE_PUT(
                 storageRepoWrite(),
                 STORAGE_REPO_ARCHIVE "/9.4-1/0000000100000000/000000010000000000000003-abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd",
@@ -2723,7 +2724,7 @@ testRun(void)
             // 40  36 4 32 32644 4 8  |
             // LPH RM P RH   B   P RH |
             record = createXRecord(RM6_HEAP_ID, XLOG_HEAP_INSERT, .body_size = sizeof(node1), .body = &node1);
-            insertXRecord(wal2, record, 0, .segno = 2, .remLen = (sizeof(node1) + SizeOfXLogRecordGPDB6) - 8, .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE);
+            insertXRecord(wal2, record, NO_FLAGS, .segno = 2, .remLen = (sizeof(node1) + SizeOfXLogRecordGPDB6) - 8, .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE);
             record = createXRecord(
                 RM_XLOG_ID,
                 XLOG_NOOP,
@@ -2752,7 +2753,7 @@ testRun(void)
             // 40  36 4 32 32644 4 8  |
             // LPH RM P RH   B   P RH |
             record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = sizeof(node1), .body = &node1);
-            insertXRecord(wal3, record, 0, .segno = 2, .remLen = (sizeof(node1) + SizeOfXLogRecordGPDB6) - 8, .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE);
+            insertXRecord(wal3, record, NO_FLAGS, .segno = 2, .remLen = (sizeof(node1) + SizeOfXLogRecordGPDB6) - 8, .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE);
             record = createXRecord(
                 RM_XLOG_ID,
                 XLOG_NOOP,
@@ -3342,7 +3343,7 @@ testRun(void)
     if (testBegin("brute force test"))
     {
         HRN_STORAGE_PUT_Z(storageTest, "recovery_filter.json", "[]");
-        const uint32 recordBodySizeSize = 128 * 1024;
+        const uint32 recordBodySize = 128 * 1024;
         const uint32 walSize = 512 * 1024;
         const PgControl pgControl = {
             .version = PG_VERSION_94,
@@ -3359,7 +3360,7 @@ testRun(void)
         };
         Buffer *wal = bufNew(walSize);
         srand(123);
-        record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = recordBodySizeSize);
+        record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .body_size = recordBodySize);
 
         for (uint32 offset = 0; offset <= DEFAULT_GDPB_XLOG_PAGE_SIZE * 2; offset += MAXIMUM_ALIGNOF)
         {

--- a/test/src/module/common/walFilterGPDB6Test.c
+++ b/test/src/module/common/walFilterGPDB6Test.c
@@ -210,6 +210,7 @@ fillWalWithRecords(Buffer *wal, uint32 targetOffset, uint32 segSize)
         insertXRecord(wal,record, NO_FLAGS, .segno = 1, .segSize = segSize);
     }
 
+    ASSERT(bufUsed(wal) + SizeOfXLogRecordGPDB6 < targetOffset);
     uint32 bodySize = (uint32) (targetOffset - bufUsed(wal) - SizeOfXLogRecordGPDB6);
     // If we are at the beginning of the page, we need to take into account its header.
     if (bufUsed(wal) % DEFAULT_GDPB_XLOG_PAGE_SIZE == 0)

--- a/test/src/module/common/walFilterGPDB7Test.c
+++ b/test/src/module/common/walFilterGPDB7Test.c
@@ -355,7 +355,7 @@ testRun(void)
         {
             wal = bufNew(1024 * 1024);
             record = createXRecord(RM7_XACT_ID, XLOG_XACT_COMMIT, .main_data_size = 100);
-            insertXRecord(wal, record, 0);
+            insertXRecord(wal, record, NO_FLAGS);
             insertWalSwitchXRecord(wal);
             fillLastPage(wal, pgPageSize32);
         }
@@ -369,7 +369,7 @@ testRun(void)
         {
             wal = bufNew(1024 * 1024);
             record = createXRecord(RM7_XACT_ID, XLOG_XACT_COMMIT, .main_data_size = 500);
-            insertXRecord(wal, record, 0);
+            insertXRecord(wal, record, NO_FLAGS);
             insertWalSwitchXRecord(wal);
             fillLastPage(wal, pgPageSize32);
         }
@@ -383,7 +383,7 @@ testRun(void)
         {
             wal = bufNew(1024 * 1024);
             record = createXRecord(RM7_XACT_ID, XLOG_XACT_COMMIT, .main_data_size = 500, .has_origin = true);
-            insertXRecord(wal, record, 0);
+            insertXRecord(wal, record, NO_FLAGS);
             insertWalSwitchXRecord(wal);
             fillLastPage(wal, pgPageSize32);
         }
@@ -413,7 +413,7 @@ testRun(void)
             lstAdd(backupBlocks, &block);
 
             record = createXRecord(RM7_XACT_ID, XLOG_XACT_COMMIT, .backupBlocks = backupBlocks);
-            insertXRecord(wal, record, 0);
+            insertXRecord(wal, record, NO_FLAGS);
             insertWalSwitchXRecord(wal);
             fillLastPage(wal, pgPageSize32);
         }
@@ -444,7 +444,7 @@ testRun(void)
             lstAdd(backupBlocks, &block);
 
             record = createXRecord(RM7_XACT_ID, XLOG_XACT_COMMIT, .backupBlocks = backupBlocks);
-            insertXRecord(wal, record, 0);
+            insertXRecord(wal, record, NO_FLAGS);
             insertWalSwitchXRecord(wal);
             fillLastPage(wal, pgPageSize32);
         }
@@ -483,7 +483,7 @@ testRun(void)
             lstAdd(backupBlocks, &block2);
 
             record = createXRecord(RM7_XACT_ID, XLOG_XACT_COMMIT, .backupBlocks = backupBlocks, .main_data_size = 1000);
-            insertXRecord(wal, record, 0);
+            insertXRecord(wal, record, NO_FLAGS);
             insertWalSwitchXRecord(wal);
             fillLastPage(wal, pgPageSize32);
         }
@@ -515,7 +515,7 @@ testRun(void)
             lstAdd(backupBlocks, &block);
 
             record = createXRecord(RM7_XACT_ID, XLOG_XACT_COMMIT, .backupBlocks = backupBlocks);
-            insertXRecord(wal, record, 0);
+            insertXRecord(wal, record, NO_FLAGS);
             insertWalSwitchXRecord(wal);
             fillLastPage(wal, pgPageSize32);
         }
@@ -549,7 +549,7 @@ testRun(void)
             lstAdd(backupBlocks, &block);
 
             record = createXRecord(RM7_XACT_ID, XLOG_XACT_COMMIT, .backupBlocks = backupBlocks);
-            insertXRecord(wal, record, 0);
+            insertXRecord(wal, record, NO_FLAGS);
             insertWalSwitchXRecord(wal);
             fillLastPage(wal, pgPageSize32);
         }
@@ -573,11 +573,11 @@ testRun(void)
                     sizeof(XLogRecordDataHeaderLong) -
                     8
                 );
-            insertXRecord(wal, record, 0);
+            insertXRecord(wal, record, NO_FLAGS);
             record = createXRecord(RM_XLOG_ID, XLOG_XACT_COMMIT, .main_data_size = pgPageSize32 * 2);
-            insertXRecord(wal, record, 0);
+            insertXRecord(wal, record, NO_FLAGS);
             record = createXRecord(RM_XLOG_ID, XLOG_XACT_COMMIT, .main_data_size = pgPageSize32 * 6);
-            insertXRecord(wal, record, 0);
+            insertXRecord(wal, record, NO_FLAGS);
             insertWalSwitchXRecord(wal);
             fillLastPage(wal, pgPageSize32);
         }

--- a/test/src/module/common/walFilterGPDB7Test.c
+++ b/test/src/module/common/walFilterGPDB7Test.c
@@ -229,7 +229,7 @@ testRun(void)
 
         wal2 = bufNew(1024 * 1024);
         record = createXRecord(RM7_XACT_ID, XLOG_XACT_COMMIT, .main_data_size = 100);
-        insertXRecord(wal2, record, NO_FLAGS, .segno = 2, .beginOffset = record->xl_tot_len - 16);
+        insertXRecord(wal2, record, NO_FLAGS, .segno = 2, .remLen = record->xl_tot_len - 16);
         insertWalSwitchXRecord(wal2);
         fillLastPage(wal2, pgPageSize32);
 
@@ -289,7 +289,7 @@ testRun(void)
             Buffer *wal1 = bufNew(DEFAULT_GDPB_XLOG_PAGE_SIZE);
 
             record = createXRecord(RM7_XACT_ID, XLOG_XACT_COMMIT, .main_data_size = 100);
-            insertXRecord(wal1, record, NO_FLAGS, .beginOffset = 110);
+            insertXRecord(wal1, record, NO_FLAGS, .remLen = 110);
             fillLastPage(wal1, DEFAULT_GDPB_XLOG_PAGE_SIZE);
 
             HRN_STORAGE_PUT(
@@ -1117,7 +1117,7 @@ testRun(void)
 
         Buffer *wal2 = bufNew(1024 * 1024);
         record = createXRecord(RM7_XACT_ID, XLOG_XACT_COMMIT, .backupBlocks = backupBlocks);
-        insertXRecord(wal2, record, NO_FLAGS, .segno = 2, .beginOffset = record->xl_tot_len - 8);
+        insertXRecord(wal2, record, NO_FLAGS, .segno = 2, .remLen = record->xl_tot_len - 8);
         insertWalSwitchXRecord(wal2);
         fillLastPage(wal2, pgPageSize32);
 
@@ -1126,7 +1126,7 @@ testRun(void)
         overrideXLogRecordBody((XLogRecordGPDB7 *) record);
         ((XLogRecordGPDB7 *) record)->xl_crc = xLogRecordChecksumGPDB7((XLogRecordGPDB7 *) record);
 
-        insertXRecord(wal_expected, record, NO_FLAGS, .segno = 2, .beginOffset = record->xl_tot_len - 8);
+        insertXRecord(wal_expected, record, NO_FLAGS, .segno = 2, .remLen = record->xl_tot_len - 8);
         insertWalSwitchXRecord(wal_expected);
         fillLastPage(wal_expected, pgPageSize32);
 
@@ -1170,7 +1170,7 @@ testRun(void)
             Buffer *wal1 = bufNew(DEFAULT_GDPB_XLOG_PAGE_SIZE);
 
             record = createXRecord(RM7_XACT_ID, XLOG_XACT_COMMIT, .backupBlocks = backupBlocks);
-            insertXRecord(wal1, record, NO_FLAGS, .beginOffset = record->xl_tot_len - 24, .segno = 2, .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE);
+            insertXRecord(wal1, record, NO_FLAGS, .remLen = record->xl_tot_len - 24, .segno = 2, .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE);
             fillLastPage(wal1, DEFAULT_GDPB_XLOG_PAGE_SIZE);
 
             HRN_STORAGE_PUT(
@@ -1273,7 +1273,7 @@ testRun(void)
             // 40  20 24
             // LPH RM RH
             record = createXRecord(RM7_XACT_ID, XLOG_XACT_COMMIT, .backupBlocks = backupBlocks);
-            insertXRecord(wal2, record, NO_FLAGS, .segno = 2, .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE, .beginOffset = 20);
+            insertXRecord(wal2, record, NO_FLAGS, .segno = 2, .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE, .remLen = 20);
             insertWalSwitchXRecord(wal2);
             fillLastPage(wal2, DEFAULT_GDPB_XLOG_PAGE_SIZE);
 
@@ -1315,7 +1315,7 @@ testRun(void)
             record = createXRecord(RM_XLOG_ID, XLOG_NOOP, .backupBlocks = backupBlocks);
             overrideXLogRecordBody((XLogRecordGPDB7 *) record);
             ((XLogRecordGPDB7 *) record)->xl_crc = xLogRecordChecksumGPDB7((XLogRecordGPDB7 *) record);
-            insertXRecord(wal2_expected, record, NO_FLAGS, .segno = 2, .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE, .beginOffset = 20);
+            insertXRecord(wal2_expected, record, NO_FLAGS, .segno = 2, .segSize = DEFAULT_GDPB_XLOG_PAGE_SIZE, .remLen = 20);
             insertWalSwitchXRecord(wal2_expected);
             fillLastPage(wal2_expected, DEFAULT_GDPB_XLOG_PAGE_SIZE);
         }


### PR DESCRIPTION
The following unit tests have been added:
1. The test is when the previous file is on a different timeline.
2. The test is when an unfinished record at the beginning of the file, is a wal
switch.
3. The test is when there is no previous file but there is an unfinished record
at the beginning that has been overwritten.
4. The test is when the last record is not finished and is a wal switch.
5. The test is when the entire file is an unfinished record and there is no
previous and next file.
6. The "brute force" test. This test creates WALs with random content in which
one of the records is in all possible positions within 2 pages.

The following integration tests have been added:
1. A partial restore test where there was a switch from the primary to the
mirror between backup and restore point.

Other improvements:
1. The beginOffset parameter has been renamed to remLen to better reflect its
purpose.
2. Unnecessary rewriting of archiveInfo.file has been removed.
3. Fixed a few typos.
4. In integration tests, the cluster initialization logic has been moved to a
separate function in a separate file.
5. Make integration tests parallel where possible.