### PR TITLE
ADBM-2573: Fix verify command edge case with all WALs missing

### DIFF
--- a/src/command/verify/verify.c
+++ b/src/command/verify/verify.c
@@ -564,7 +564,6 @@ verifyUpdateWalFilesMissing(
     ASSERT(backupList != NULL);
     ASSERT(archiveIdResult != NULL);
     ASSERT(missingStart == NULL || missingStop == NULL || strCmp(missingStart, missingStop) <= 0);
-    ASSERT(missingStart != NULL || missingStop != NULL);
 
     MEM_CONTEXT_TEMP_BEGIN()
     {
@@ -586,10 +585,14 @@ verifyUpdateWalFilesMissing(
             ASSERT(strCmp(backup->archiveStart, backup->archiveStop) <= 0);
 
             // We do not process backups from the wrong timeline
-            const String *const anyMissing = missingStart ? missingStart : missingStop;
-            const String *const missingTimeline = strSubN(anyMissing, 0, 8);
-            const String *const backupTimeline = strSubN(backup->archiveStart, 0, 8);
-            bool wrongTimeline = !strEq(missingTimeline, backupTimeline);
+            bool wrongTimeline = false;
+            if (missingStart || missingStop)
+            {
+                const String *const anyMissing = missingStart ? missingStart : missingStop;
+                const String *const missingTimeline = strSubN(anyMissing, 0, 8);
+                const String *const backupTimeline = strSubN(backup->archiveStart, 0, 8);
+                wrongTimeline = !strEq(missingTimeline, backupTimeline);
+            }
             // Backups have inclusive ranges, so [A, B] is placed before [C, D) if B < C (so A <= B < C < D)
             // but [A, B] is placed after [C, D) if D <= A (so C < D <= A <= B).
             // We skip any backups that don't overlap the range with missing files.
@@ -598,9 +601,13 @@ verifyUpdateWalFilesMissing(
             if (wrongTimeline || backupIsBeforeRange || backupIsAfterRange)
                 continue;
 
+            size_t walSegmentSize = (size_t)archiveIdResult->pgWalInfo.size;
+            if (walSegmentSize == 0)
+                walSegmentSize = pgWalSegmentSizeDefault(backup->pgVersion);
+
             // Convert inclusive range [start, stop] to exclusive [start, stop+1)
             const String *const backupStopExclusive =
-                walSegmentNext(backup->archiveStop, (size_t)archiveIdResult->pgWalInfo.size, archiveIdResult->pgWalInfo.version);
+                walSegmentNext(backup->archiveStop, walSegmentSize, backup->pgVersion);
             // Overlap of ranges [A, B) and [C, D) is [max(A, C), min(B, D))
             // Since NULLs in missing file range corresponds to negative/positive infinity,
             // we can simply choose the other value if NULL is present.
@@ -610,8 +617,7 @@ verifyUpdateWalFilesMissing(
             const String *const overlapEnd = missingStop && strCmp(backupStopExclusive, missingStop) > 0 ?
                                                  missingStop : backupStopExclusive;
             int overlapSize = walSegmentDist(overlapStart, overlapEnd,
-                                             (size_t)archiveIdResult->pgWalInfo.size,
-                                             archiveIdResult->pgWalInfo.version);
+                                             walSegmentSize, backup->pgVersion);
             ASSERT(overlapSize >= 0);
 
             if (overlapSize > 0)
@@ -2115,10 +2121,9 @@ verifyProcess(const bool verboseText)
                                                   archiveIdResult->pgWalInfo.version);
                     }
 
-                    // If we had at least one WAL range, mark all files after the last range as missing
-                    if (gapStart != NULL)
-                        verifyUpdateWalFilesMissing(jobData.backupResultList, archiveIdResult,
-                                                    gapStart, NULL, &jobData.jobErrorTotal);
+                    // Mark all files after the last range as missing
+                    verifyUpdateWalFilesMissing(jobData.backupResultList, archiveIdResult,
+                                                gapStart, NULL, &jobData.jobErrorTotal);
                 }
 
                 // Report results

--- a/src/command/verify/verify.c
+++ b/src/command/verify/verify.c
@@ -586,7 +586,7 @@ verifyUpdateWalFilesMissing(
 
             // We do not process backups from the wrong timeline
             bool wrongTimeline = false;
-            if (missingStart || missingStop)
+            if (missingStart != NULL || missingStop != NULL)
             {
                 const String *const anyMissing = missingStart ? missingStart : missingStop;
                 const String *const missingTimeline = strSubN(anyMissing, 0, 8);

--- a/test/src/module/command/verifyTest.c
+++ b/test/src/module/command/verifyTest.c
@@ -3544,6 +3544,44 @@ testRun(void)
             "P00 DETAIL: archiveId: 11-2, wal start: 000000050000000800000003, wal stop: 000000050000000800000004");
 
         // -------------------------------------------------------------------------------------------------------------------------
+        TEST_TITLE("--set with all WALs missing");
+
+        HRN_STORAGE_REMOVE(
+            storageRepoIdxWrite(0),
+            zNewFmt(STORAGE_REPO_ARCHIVE "/11-2/0000000500000008/000000050000000800000003-%s", walBufferSha1),
+            .comment = "remove WAL");
+
+        TEST_RESULT_STR_Z(
+            verifyProcess(cfgOptionBool(cfgOptVerbose)),
+            "stanza: db\n"
+            "status: error\n"
+            "  archiveId: 11-2, total WAL checked: 1, total valid WAL: 1\n"
+            "    missing: 0, checksum invalid: 0, size invalid: 0, wal invalid: 0, other: 0\n"
+            "  backup: 20181119-153300F, status: invalid, total files checked: 1, total valid files: 1\n"
+            "    missing: 0, checksum invalid: 0, size invalid: 0, wal invalid: 1, other: 0", "--set with missing WALs\n");
+        TEST_RESULT_LOG(
+            "P00 DETAIL: path '11-2/0000000500000007' does not contain any valid WAL to be processed\n"
+            "P00 DETAIL: path '11-2/0000000500000009' does not contain any valid WAL to be processed\n"
+            "P00 DETAIL: archiveId: 11-2, wal start: 000000050000000800000004, wal stop: 000000050000000800000004");
+
+        HRN_STORAGE_REMOVE(
+            storageRepoIdxWrite(0),
+            zNewFmt(STORAGE_REPO_ARCHIVE "/11-2/0000000500000008/000000050000000800000004-%s", walBufferSha1),
+            .comment = "remove WAL");
+
+        TEST_RESULT_STR_Z(
+            verifyProcess(cfgOptionBool(cfgOptVerbose)),
+            "stanza: db\n"
+            "status: error\n"
+            "  archiveId: 11-2, total WAL checked: 0, total valid WAL: 0\n"
+            "  backup: 20181119-153300F, status: invalid, total files checked: 1, total valid files: 1\n"
+            "    missing: 0, checksum invalid: 0, size invalid: 0, wal invalid: 2, other: 0", "--set with missing WALs\n");
+        TEST_RESULT_LOG(
+            "P00 DETAIL: path '11-2/0000000500000007' does not contain any valid WAL to be processed\n"
+            "P00 DETAIL: path '11-2/0000000500000008' does not contain any valid WAL to be processed\n"
+            "P00 DETAIL: path '11-2/0000000500000009' does not contain any valid WAL to be processed");
+
+        // -------------------------------------------------------------------------------------------------------------------------
         TEST_TITLE("--set with archive and broken backup");
 
         argList = strLstDup(argListBase);


### PR DESCRIPTION
Fix verify command edge case with all WALs missing

Previously logic added by 7acf5a43bb2d5e20c2809b9335fae4172b11d56a had a bug
that prevented it from reporting an error when all WALs were missing, not just
one. In that case, no WALs were processed, so verifyUpdateWalFilesMissing
wasn't called at all.

Add logic to verifyUpdateWalFilesMissing to handle being called on the whole
WAL range (represented by both missingStart and missingStop being NULLs), and
call it unconditionally at the end of archive processing, to ensure it is
called at least once for every archive.