### PR TITLE
ADBM-2801: Disable logging in signal handlers

### DIFF
--- a/src/command/exit.c
+++ b/src/command/exit.c
@@ -54,13 +54,12 @@ Catch signals
 static void
 exitOnSignal(const int signalType)
 {
-    FUNCTION_LOG_BEGIN(logLevelTrace);
-        FUNCTION_LOG_PARAM(INT, signalType);
-    FUNCTION_LOG_END();
+    // It is not safe to log anything inside signal handlers, since many
+    // functions used in logging are not reentrant.
+    // Disable it here to avoid deadlocks.
+    logInit(logLevelOff, logLevelOff, logLevelOff, false, 0, 1, false);
 
     exit(exitSafe(errorTypeCode(&TermError), false, (SignalType)signalType));
-
-    FUNCTION_LOG_RETURN_VOID();
 }
 
 /**********************************************************************************************************************************/


### PR DESCRIPTION
Disable logging in signal handlers

Currently pgbackrest allows logging in signal handler exitOnSignal in exit.c.
Logging uses various locking operations (like gmtime) and also static internal
state, so if the signal occurs during logging, and then the signal handler
tries to log something else, this can lead to deadlocks and undefined
behavior.

Instead disable all logging inside signal handlers, since it does not contain
crucial info anyway. Tests are not added since there doesn't seem to be a
simple way to check the logs of a process that already exited.
