### PR TITLE
ADBM-2878: Research reconcile backup.info with backups on disk

### DIFF
--- a/src/command/verify/verify.c
+++ b/src/command/verify/verify.c
@@ -1910,6 +1910,19 @@ verifyProcess(const bool verboseText)
                         storage, STORAGE_REPO_BACKUP_STR,
                         .expression = backupRegExpStr),
                     sortOrderAsc);
+
+                // Warn if backups on disk are not described in backup.info
+                for (unsigned int repoIdx = 0; repoIdx < strLstSize(jobData.backupList); repoIdx++)
+                {
+                    const String *const label = strLstGet(jobData.backupList, repoIdx);
+
+                    if (!infoBackupLabelExists(backupInfo, label))
+                    {
+                        LOG_WARN_FMT(
+                            "backup '%s' is not described in " INFO_BACKUP_FILE,
+                            strZ(label));
+                    }
+                }
             }
             else
                 jobData.backupList = strLstNew();
@@ -1945,6 +1958,31 @@ verifyProcess(const bool verboseText)
             {
                 verifyCollectBackupRange(&jobData, backupLabel);
                 jobData.enableArchiveFilter = true;
+            }
+
+            // Check if backup.info contains backups not on disk and add them for processing.
+            if (!backupLabelInvalid && backupLabel == NULL)
+            {
+                const StringList *infoBackupLabelList = infoBackupDataLabelList(backupInfo, NULL);
+
+                for (unsigned int infoIdx = 0; infoIdx < strLstSize(infoBackupLabelList); infoIdx++)
+                {
+                    const String *infoLabel = strLstGet(infoBackupLabelList, infoIdx);
+
+                    if (strLstFindIdxP(jobData.backupList, infoLabel) == LIST_NOT_FOUND)
+                    {
+                        LOG_WARN_FMT(
+                            "backup '%s' exists in " INFO_BACKUP_FILE " but was not found on disk",
+                            strZ(infoLabel));
+
+                        MEM_CONTEXT_BEGIN(jobData.memContext)
+                        {
+                            strLstAdd(jobData.backupList, strDup(infoLabel));
+                        }
+                        MEM_CONTEXT_END();
+                    }
+                }
+                jobData.backupList = strLstSort(jobData.backupList, sortOrderAsc);
             }
 
             // Only begin processing if there are some archives or backups in the repo


### PR DESCRIPTION
Update the verify command to compare backup.info with the actual backups in the 
stanza, warn about mismatches, and report missing backups with manifest missing
status.

Note: Research only — do not merge.
