### PR TITLE
ADBM-2937: Fix pgbackrest doc test on RH8

### DIFF
--- a/doc/resource/exe.cache
+++ b/doc/resource/exe.cache
@@ -308,7 +308,7 @@
                   "name" : "azure-server",
                   "option" : "-v {[host-repo-path]}/doc/resource/fake-cert/azure-server.crt:/root/public.crt:ro -v {[host-repo-path]}/doc/resource/fake-cert/azure-server.key:/root/private.key:ro -e AZURITE_ACCOUNTS='pgbackrest:YXpLZXk='",
                   "os" : "debian",
-                  "param" : "azurite-blob --blobPort 443 --blobHost 0.0.0.0 --cert=/root/public.crt --key=/root/private.key",
+                  "param" : "azurite-blob --blobPort 443 --blobHost 0.0.0.0 --cert=/root/public.crt --key=/root/private.key --skipApiVersionCheck",
                   "update-hosts" : false
                },
                "type" : "host",
@@ -6866,7 +6866,7 @@
                   "name" : "azure-server",
                   "option" : "-v {[host-repo-path]}/doc/resource/fake-cert/azure-server.crt:/root/public.crt:ro -v {[host-repo-path]}/doc/resource/fake-cert/azure-server.key:/root/private.key:ro -e AZURITE_ACCOUNTS='pgbackrest:YXpLZXk='",
                   "os" : "rhel",
-                  "param" : "azurite-blob --blobPort 443 --blobHost 0.0.0.0 --cert=/root/public.crt --key=/root/private.key",
+                  "param" : "azurite-blob --blobPort 443 --blobHost 0.0.0.0 --cert=/root/public.crt --key=/root/private.key --skipApiVersionCheck",
                   "update-hosts" : false
                },
                "type" : "host",

--- a/doc/xml/user-guide.xml
+++ b/doc/xml/user-guide.xml
@@ -390,6 +390,13 @@
         "enabled=1" \
         "gpgcheck=1" \
         "gpgkey=https://yum.postgresql.org/keys/PGDG-RPM-GPG-KEY-RHEL" > /etc/yum.repos.d/pgdg-12.repo
+        RUN printf "%s\n" \
+        "[pgdg13-archive]" \
+        "name=PostgreSQL 13 RPMs for RHEL/Rocky Linux/AlmaLinux 8" \
+        "baseurl=https://yum-archive.postgresql.org/13/redhat/rhel-8-x86_64" \
+        "enabled=1" \
+        "gpgcheck=1" \
+        "gpgkey=https://yum.postgresql.org/keys/PGDG-RPM-GPG-KEY-RHEL" > /etc/yum.repos.d/pgdg-13.repo
 
 
 

--- a/doc/xml/user-guide.xml
+++ b/doc/xml/user-guide.xml
@@ -905,7 +905,7 @@
         <title>Introduction</title>
 
         <!-- Create Azure server first to allow it time to boot before being used -->
-        <host-add if="'{[azure-local]}' eq 'y'" id="{[host-azure-id]}" name="{[host-azure]}" user="root" image="{[azure-image]}" os="{[os-type]}" option="-v {[fake-cert-path]}/azure-server.crt:/root/public.crt:ro -v {[fake-cert-path]}/azure-server.key:/root/private.key:ro -e AZURITE_ACCOUNTS='{[azure-account]}:{[azure-key]}'" param="azurite-blob --blobPort 443 --blobHost 0.0.0.0 --cert=/root/public.crt --key=/root/private.key" update-hosts="n"/>
+        <host-add if="'{[azure-local]}' eq 'y'" id="{[host-azure-id]}" name="{[host-azure]}" user="root" image="{[azure-image]}" os="{[os-type]}" option="-v {[fake-cert-path]}/azure-server.crt:/root/public.crt:ro -v {[fake-cert-path]}/azure-server.key:/root/private.key:ro -e AZURITE_ACCOUNTS='{[azure-account]}:{[azure-key]}'" param="azurite-blob --blobPort 443 --blobHost 0.0.0.0 --cert=/root/public.crt --key=/root/private.key --skipApiVersionCheck" update-hosts="n"/>
 
         <!-- Create S3 server first to allow it time to boot before being used -->
         <host-add if="'{[s3-local]}' eq 'y'" id="{[host-s3-id]}" name="{[host-s3]}" user="root" image="{[s3-image]}" os="{[os-type]}" option="-v {[fake-cert-path]}/s3-server.crt:/root/.minio/certs/public.crt:ro -v {[fake-cert-path]}/s3-server.key:/root/.minio/certs/private.key:ro -e MINIO_REGION={[s3-region]} -e MINIO_DOMAIN={[s3-endpoint]} -e MINIO_BROWSER=off -e MINIO_ACCESS_KEY={[s3-key]} -e MINIO_SECRET_KEY={[s3-key-secret]}" param="server /data --address :443" update-hosts="n"/>


### PR DESCRIPTION
The az tool used to create the bucket now requires an API version greater than what Azurite supports. This may be a mistake on their part (but has not resolved after a day) or may indicate that Azurite is no longer actively supported.

Either way, for now it is easiest to suppress the version check so CI builds can proceed. Other corrective action can be taken later as needed.

(cherry picked from commit https://github.com/arenadata/pgbackrest/commit/b52ebe1fd840d504808a850379bf82439cf50065)

Changes compared to the original commit:
- Our branch got a cache mismatch issue. It wasn't observed on the
  upstream because results of the build-package test depend on the project
  version specified in the src/version.h. If the version has the
  'dev' suffix, a special code path will be chosen, modifying the test file.

  It doesn't seem that we can easily change the version though,
  as there is other logic bound to it. Instead, just update the cache.
---
Use archive yum repos to get PostgreSQL 13.