### PR TITLE
ADBM-2955: Update pgbackrest tests according to changed docker inspect output

### DIFF
--- a/doc/lib/pgBackRestDoc/Common/Host.pm
+++ b/doc/lib/pgBackRestDoc/Common/Host.pm
@@ -67,7 +67,10 @@ sub new
                 {bSuppressStdErr => true});
 
     # Get IP Address
-    $self->{strIP} = trim(executeTest("docker inspect --format '\{\{ .NetworkSettings.IPAddress \}\}' $self->{strContainer}"));
+    $self->{strIP} = trim(
+        executeTest(
+            "docker inspect --format '\{\{range .NetworkSettings.Networks\}\}\{\{.IPAddress\}\}\{\{end\}\}'" .
+            " $self->{strContainer}"));
     $self->{bActive} = true;
 
     # Return from function and log return values if any

--- a/test/src/common/harnessHost.c
+++ b/test/src/common/harnessHost.c
@@ -186,7 +186,10 @@ hrnHostNew(const StringId id, const String *const container, const String *const
 
             // Get IP address
             const String *const ip = strTrim(
-                execOneP(strNewFmt("docker inspect --format '{{ .NetworkSettings.IPAddress }}' %s", strZ(hrnHostContainer(this)))));
+                execOneP(
+                    strNewFmt(
+                        "docker inspect --format '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' %s",
+                        strZ(hrnHostContainer(this)))));
 
             MEM_CONTEXT_PRIOR_BEGIN()
             {


### PR DESCRIPTION
The IP address has been moved in newer versions of Docker but this expression will fetch the IP address from the old or new location.

(cherry picked from commit 2b6a1de295160ddb016a7d65c8f5c08ff408b02c)

Note: 
- This api was deprecated since [Docker 1.9.0](https://docs.docker.com/engine/release-notes/prior-releases/#190-2015-11-03), which was released back in 2015.  
- This branch is intended to merged with rebase.
